### PR TITLE
Improved response-status-line and x-content-type-name

### DIFF
--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterTest.java
@@ -457,7 +457,7 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
 
     // id request.......................................................................................................
 
-    private final static String RESOURCE_SUCCESSFUL = HttpMethod.POST + " resource successful";
+    private final static String RESOURCE_SUCCESSFUL = HttpMethod.POST + " " + TestResource.class.getSimpleName() + " No content";
 
     @Test
     public void testRequestResourceBodyAbsentId() {
@@ -691,7 +691,7 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                            },
                 "/api/resource1/0x123/contents",
                 NO_BODY,
-                HttpStatusCode.OK.status().setMessage(RESOURCE_SUCCESSFUL),
+                HttpStatusCode.OK.status().setMessage("POST " + TestResource.class.getSimpleName() + " OK"),
                 this.httpEntity(RESOURCE_OUT));
     }
 
@@ -725,7 +725,7 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                            },
                 "/api/resource1/0x123-0x456/contents",
                 NO_BODY,
-                HttpStatusCode.OK.status().setMessage(RESOURCE_SUCCESSFUL),
+                HttpStatusCode.OK.status().setMessage("POST " + TestResource.class.getSimpleName() + " OK"),
                 this.httpEntity(COLLECTION_RESOURCE_OUT));
     }
 


### PR DESCRIPTION
- Replaced previous generic response status line messages with $method $typename $status-message,
 eg: POST SpreadsheetMetadata No content
- x-content-type-name header previously did getClass().getSimpleName()