### PR TITLE
Router GET ignores content-type

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouter.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouter.java
@@ -86,11 +86,9 @@ final class HateosResourceMappingRouter implements Router<HttpRequestAttribute<?
         final Optional<MediaType> contentType = HttpHeaderName.CONTENT_TYPE.parameterValue(parameters);
 
         // Optional.stream is not supported in J2cl hence the alternative.
-        return HttpMethod.GET.equals(method) ?
-                !contentType.isPresent() :// contentType should be missing because GET dont have a body
-                contentType.map(this::isContentTypeCompatible)
-                        .orElse(false) &&
-                        -1 != this.consumeBasePath(parameters);
+        return HttpMethod.GET.equals(method) || contentType.map(this::isContentTypeCompatible)
+                .orElse(false) &&
+                -1 != this.consumeBasePath(parameters);
     }
 
     /**

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterTest.java
@@ -95,10 +95,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
     }
 
     @Test
-    public void testGetWrongContentTypeUnrouted() {
+    public void testNonGetWrongContentTypeFails() {
         this.routeFails(
                 this.request(
-                        HttpMethod.GET,
+                        HttpMethod.POST,
                         "/api/",
                         MediaType.parse("text/plain;q=1"),
                         ""
@@ -107,7 +107,7 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
     }
 
     @Test
-    public void testWrongContentTypeUnrouted() {
+    public void testNonGetWrongContentTypeUnrouted() {
         this.routeFails(
                 this.request(
                         HttpMethod.POST,


### PR DESCRIPTION
- Necessary because browser fetch defaults to sending text/plain