### PR TITLE
Handle unknown LinkRelation bad request Fix

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterBiConsumerRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterBiConsumerRequest.java
@@ -189,7 +189,7 @@ final class HateosResourceMappingRouterBiConsumerRequest {
     }
 
     /**
-     * Validates that the request method is supported for the given {@link HateosResourceMapping}
+     * Validates that the request method and {@link LinkRelation} is supported for the given {@link HateosResourceMapping}
      */
     private void methodSupportedTest(final HateosResourceMapping<?, ?, ?, ?> mapping,
                                      final HateosResourceSelection<?> selection,
@@ -197,10 +197,24 @@ final class HateosResourceMappingRouterBiConsumerRequest {
         final HttpMethod method = this.request.method();
 
         final List<HttpMethod> supportedMethods = mapping.relationToMethods.get(relation);
-        if (null != supportedMethods && supportedMethods.contains(method)) {
-            this.locateHandlerParseRequestBodyDispatchSetResponseStatusCode(mapping, selection, relation, method);
+        if (null == supportedMethods) {
+            this.badRequest(
+                    "Unknown link relation " +
+                            CharSequences.quoteAndEscape(
+                                    relation.toHeaderText()
+                            )
+            );
         } else {
-            this.methodNotAllowed(mapping.resourceName, relation, supportedMethods);
+            if (supportedMethods.contains(method)) {
+                this.locateHandlerParseRequestBodyDispatchSetResponseStatusCode(
+                        mapping,
+                        selection,
+                        relation,
+                        method
+                );
+            } else {
+                this.methodNotAllowed(mapping.resourceName, relation, supportedMethods);
+            }
         }
     }
 

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterTest.java
@@ -244,6 +244,14 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
     }
 
     @Test
+    public void testBadRequestUnknownRelation() {
+        this.routeAndCheck(
+                "/api/resource-with-body/0x1/clear",
+                HttpStatusCode.BAD_REQUEST.setMessage("Unknown link relation \"clear\"")
+        );
+    }
+
+    @Test
     public void testMethodNotSupported() {
         this.methodNotSupportedAndCheck("AAA");
     }


### PR DESCRIPTION
- Fixes a NPE
```
java.lang.NullPointerException: value
	at java.base/java.util.Objects.requireNonNull(Objects.java:246)
	at walkingkooka.net.header.HeaderHandler.check(HeaderHandler.java:350)
	at walkingkooka.net.header.HttpHeaderName.check(HttpHeaderName.java:783)
	at walkingkooka.net.http.HttpEntityHeaderOneList.with(HttpEntityHeaderOneList.java:43)
	at walkingkooka.net.http.HttpEntityHeaderList.one(HttpEntityHeaderList.java:38)
	at walkingkooka.net.http.HttpEntityEmpty.addHeader0(HttpEntityEmpty.java:72)
	at walkingkooka.net.http.HttpEntity.addHeader(HttpEntity.java:138)
	at walkingkooka.net.http.server.hateos.HateosResourceMappingRouterBiConsumerRequest.methodNotAllowed(HateosResourceMappingRouterBiConsumerRequest.java:226)
	at walkingkooka.net.http.server.hateos.HateosResourceMappingRouterBiConsumerRequest.methodSupportedTest(HateosResourceMappingRouterBiConsumerRequest.java:203)
	at walkingkooka.net.http.server.hateos.HateosResourceMappingRouterBiConsumerRequest.extractLinkRelation(HateosResourceMappingRouterBiConsumerRequest.java:163)
	at walkingkooka.net.http.server.hateos.HateosResourceMappingRouterBiConsumerRequest.parseSelectionOrBadRequest(HateosResourceMappingRouterBiConsumerRequest.java:147)
	at walkingkooka.net.http.server.hateos.HateosResourceMappingRouterBiConsumerRequest.handleResourceNameOrNotFound(HateosResourceMappingRouterBiConsumerRequest.java:123)
	at walkingkooka.net.http.server.hateos.HateosResourceMappingRouterBiConsumerRequest.extractResourceNameOrBadRequest(HateosResourceMappingRouterBiConsumerRequest.java:112)
	at walkingkooka.net.http.server.hateos.HateosResourceMappingRouterBiConsumerRequest.dispatch(HateosResourceMappingRouterBiConsumerRequest.java:95)
	at walkingkooka.net.http.server.hateos.HateosResourceMappingRouterBiConsumer.accept(HateosResourceMappingRouterBiConsumer.java:70)
```