### PR TITLE
HateosHandler creating POST returns CREATED not OK

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterBiConsumerRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterBiConsumerRequest.java
@@ -268,6 +268,7 @@ final class HateosResourceMappingRouterBiConsumerRequest {
                     }
 
                     this.setStatusAndBody(
+                            selection,
                             responseText,
                             selection.resourceType(mapping)
                     );
@@ -440,14 +441,16 @@ final class HateosResourceMappingRouterBiConsumerRequest {
     /**
      * Sets the status and message to match the content.
      */
-    void setStatusAndBody(final String content,
+    void setStatusAndBody(final HateosResourceSelection<?> selection,
+                          final String content,
                           final Class<?> contentValueType) {
 
         final HttpStatusCode statusCode;
 
         final HttpEntity entity;
         if (null != content) {
-            statusCode = HttpStatusCode.OK;
+            // CREATED if HateosResourceSuccess.none and OK for others
+            statusCode = selection.successStatusCode();
 
             final CharsetName charsetName = this.selectCharsetName();
             final HateosContentType hateosContentType = this.hateosContentType();

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelection.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelection.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.collect.Range;
+import walkingkooka.net.http.HttpStatusCode;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
 import java.util.List;
@@ -69,6 +70,15 @@ public abstract class HateosResourceSelection<I extends Comparable<I>> {
      */
     HateosResourceSelection() {
         super();
+    }
+
+    /**
+     * The status code when the response is NOT empty.
+     */
+    HttpStatusCode successStatusCode() {
+        return this.isNone() ?
+                HttpStatusCode.CREATED :
+                HttpStatusCode.OK;
     }
 
     /**

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterTest.java
@@ -796,6 +796,42 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
         this.checkEquals(expected, resource, "resource");
     }
 
+    // response none......................................................................................................
+
+    @Test
+    public void testResponseNoneIdResourceBodyAbsent() {
+        this.routeAndCheck(
+                new FakeHateosHandler<>() {
+
+                    @Override
+                    public Optional<TestResource> handleNone(final Optional<TestResource> resource,
+                                                             final Map<HttpRequestAttribute<?>, Object> parameters) {
+                        return Optional.empty();
+                    }
+                },
+                "/api/resource-with-body",
+                NO_BODY,
+                HttpStatusCode.NO_CONTENT.status()
+        );
+    }
+
+    @Test
+    public void testResponseNoneIdResourceBodyJson() {
+        this.routeAndCheck(
+                new FakeHateosHandler<>() {
+                    @Override
+                    public Optional<TestResource> handleNone(final Optional<TestResource> resource,
+                                                             final Map<HttpRequestAttribute<?>, Object> parameters) {
+                        return Optional.of(RESOURCE_OUT);
+                    }
+                },
+                "/api/resource-with-body",
+                NO_BODY,
+                HttpStatusCode.CREATED.status(),
+                this.httpEntity(RESOURCE_OUT)
+        );
+    }
+
     // response id......................................................................................................
 
     @Test
@@ -967,6 +1003,7 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 .set(LinkRelation.SELF, HttpMethod.GET, handler);
 
         final HateosResourceMapping<BigInteger, TestResource, TestResource, TestHateosResource> mappingWithBody = this.mappingWithBody()
+                .set(LinkRelation.SELF, HttpMethod.POST, handler)
                 .set(LinkRelation.with("a1"), HttpMethod.POST, handler)
                 .set(LinkRelation.CONTENTS, HttpMethod.PUT, handler)
                 .set(LinkRelation.CONTENTS, HttpMethod.DELETE, handler)


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net-http-server-hateos/issues/127
- if a POST that creates (no id present in url) it should return 201 not 200