### PR TITLE
Minor POM fixes unable to fix not invoked it-gwt-jar apts

### DIFF
--- a/gwt-pom.xml
+++ b/gwt-pom.xml
@@ -87,6 +87,12 @@
     <dependencies>
         <dependency>
             <groupId>walkingkooka</groupId>
+            <artifactId>gwt-java-util-Locale</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>walkingkooka</groupId>
             <artifactId>walkingkooka-net-gwt</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,13 @@
     </pluginRepositories>
 
     <dependencies>
+        <!-- must guarantee jre Locale is shadowed-->
+        <dependency>
+            <groupId>walkingkooka</groupId>
+            <artifactId>j2cl-java-util-Locale</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
         <dependency>
             <groupId>walkingkooka</groupId>
             <artifactId>walkingkooka-net</artifactId>

--- a/src/it/gwt-jar-test/pom.xml
+++ b/src/it/gwt-jar-test/pom.xml
@@ -16,6 +16,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>walkingkooka</groupId>
+            <artifactId>gwt-java-util-Locale</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
@@ -52,6 +58,28 @@
                 <configuration>
                     <source>9</source>
                     <target>9</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>walkingkooka</groupId>
+                            <artifactId>j2cl-java-util-currency-annotation-processor</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                        </path>
+                        <path>
+                            <groupId>walkingkooka</groupId>
+                            <artifactId>j2cl-java-util-Locale-annotation-processor</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                        </path>
+                        <path>
+                            <groupId>walkingkooka</groupId>
+                            <artifactId>j2cl-java-text-annotation-processor</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                        </path>
+                        <path>
+                            <groupId>walkingkooka</groupId>
+                            <artifactId>j2cl-java-util-TimeZone-annotation-processor</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                        </path>
+                    </annotationProcessorPaths>
                     <compilerArgs>
                         <arg>-Awalkingkooka.j2cl.java.util.Currency=XXX</arg>
                         <arg>-Awalkingkooka.j2cl.java.util.Locale=EN-AU</arg>


### PR DESCRIPTION
- it/gwt-jar-test is not invoking annotation procesors (apt) resulting in missing references to generated classes such as LocaleProvider.
- No idea why this is happening as the it/gwt-jar-test/pom.xml is identical to other successful it/gwt-jar-test/pom.xml files.