### PR TITLE
HateosResourceTesting missing type parameter I FIX

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceTesting.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceTesting.java
@@ -23,7 +23,7 @@ import walkingkooka.reflect.ClassTesting2;
 /**
  * Mixin interface for testing {@link HateosResource}
  */
-public interface HateosResourceTesting<H extends HateosResource> extends ClassTesting2<H> {
+public interface HateosResourceTesting<H extends HateosResource<I>, I> extends ClassTesting2<H> {
 
     H createHateosResource();
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net-http-server-hateos/issues/131
- HateosResourceTesting type parameter contains raw. Missing type parameter I