### PR TITLE
HateosResourceMapping collection type interface & array check

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMapping.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMapping.java
@@ -79,6 +79,14 @@ public final class HateosResourceMapping<I extends Comparable<I>, V, C, H extend
         Objects.requireNonNull(selection, "selection");
         Objects.requireNonNull(valueType, "valueType");
         Objects.requireNonNull(collectionType, "collectionType");
+
+        if (collectionType.isInterface()) {
+            throw new IllegalArgumentException("Collection type " + collectionType.getName() + " is an interface expected concrete class");
+        }
+        if (collectionType.isArray()) {
+            throw new IllegalArgumentException("Collection type " + collectionType.getName() + " is an array expected concrete class");
+        }
+
         Objects.requireNonNull(resourceType, "resourceType");
 
         return new HateosResourceMapping<>(resourceName,

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingTest.java
@@ -29,6 +29,7 @@ import walkingkooka.reflect.JavaVisibility;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -74,6 +75,42 @@ public final class HateosResourceMappingTest extends HateosResourceMappingTestCa
                 this.valueType(),
                 null,
                 this.resourceType());
+    }
+
+    @Test
+    public void testWithInterfaceCollectionTypeFails() {
+        final IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> HateosResourceMapping.with(
+                        this.resourceName(),
+                        this.selection(),
+                        this.valueType(),
+                        Collection.class,
+                        this.resourceType()
+                )
+        );
+        this.checkEquals(
+                "Collection type java.util.Collection is an interface expected concrete class",
+                thrown.getMessage()
+        );
+    }
+
+    @Test
+    public void testWithArrayCollectionTypeFails() {
+        final IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> HateosResourceMapping.with(
+                        this.resourceName(),
+                        this.selection(),
+                        this.valueType(),
+                        Object[].class,
+                        this.resourceType()
+                )
+        );
+        this.checkEquals(
+                "Collection type [Ljava.lang.Object; is an array expected concrete class",
+                thrown.getMessage()
+        );
     }
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net-http-server-hateos/issues/139
- HateosResourceMapping.with collection type should probably complain if is List | Set | Collection