### PR TITLE
HatoesResourceHandler.responses NO_CONTENT set X_CONTENT_TYPE_NAME

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceHandler.java
@@ -29,6 +29,8 @@ import java.util.Set;
 /**
  * Handles a HATEOS request for one or more {@link HateosResource} handling the unmarshalling of the request body and
  * marshalling of the response to the response body.
+ * Note that 2xx responses, especially {@link walkingkooka.net.http.HttpStatusCode#OK} and {@link walkingkooka.net.http.HttpStatusCode#NO_CONTENT},
+ * response should always contain {@link HateosResourceMapping#X_CONTENT_TYPE_NAME}, which is used by the client to dispatch watcher events.
  */
 public interface HateosResourceHandler<I extends Comparable<I>, V, C, X extends HateosResourceHandlerContext> {
 

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterHttpHandlerRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterHttpHandlerRequest.java
@@ -550,7 +550,6 @@ final class HateosResourceMappingRouterHttpHandlerRequest {
 
             entity = HttpEntity.EMPTY
                     .setContentType(contentType.setCharset(charsetName))
-                    .addHeader(HateosResourceMapping.X_CONTENT_TYPE_NAME, contentValueType.getSimpleName()) // this header is used a hint about the response.
                     .setBodyText(content)
                     .setContentLength();
         } else {
@@ -559,7 +558,15 @@ final class HateosResourceMappingRouterHttpHandlerRequest {
         }
 
         this.setStatus(statusCode.status());
-        this.response.setEntity(entity);
+
+        // This header is used to dispatch FetcherWatcher#onXXX.
+        // Even NO_CONTENT responses require this header so the web app will be aware of successful DELETEs(which reply with NO_CONTENT).
+        this.response.setEntity(
+                entity.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        contentValueType.getSimpleName()
+                )
+        );
     }
 
     private CharsetName selectCharsetName() {

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterTest.java
@@ -86,6 +86,8 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
 
     private final static MediaType CONTENT_TYPE = MediaType.parse("application/test-json");
 
+    private final static String RESOURCE_TYPE_NAME = TestResource.class.getSimpleName();
+
     private final static CharsetName DEFAULT_CHARSET = CharsetName.UTF_8;
 
     private final static Set<HateosResourceMapping<?, ?, ?, ?, ?>> MAPPINGS = Sets.empty();
@@ -425,7 +427,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 map(HttpHeaderName.ACCEPT, Accept.with(Lists.of(this.contentType()))),
                 "",
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -447,7 +452,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 map(HttpHeaderName.ACCEPT, Accept.with(Lists.of(this.contentType()))),
                 "",
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -706,7 +714,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 "/api/resource-with-body/0x123/contents",
                 NO_BODY,
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -728,7 +739,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 "/api/resource-with-body/0x123/contents",
                 "",
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -750,7 +764,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 "/api/resource-with-body/0x123/contents",
                 this.toJson(RESOURCE_IN),
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -774,7 +791,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 this.contentTypeUtf16(),
                 this.toJson(RESOURCE_IN),
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -805,7 +825,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 "/api/resource-with-body/*/contents",
                 NO_BODY,
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -825,7 +848,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 "/api/resource-with-body/*/contents",
                 "",
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -845,7 +871,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 "/api/resource-with-body/*/contents",
                 this.toJson(COLLECTION_RESOURCE_IN),
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -870,7 +899,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 "/api/resource-with-body/0x123-0x456/contents",
                 NO_BODY,
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -892,7 +924,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 "/api/resource-with-body/0x123-0x456/contents",
                 "",
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -914,7 +949,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 "/api/resource-with-body/0x123-0x456/contents",
                 this.toJson(COLLECTION_RESOURCE_IN),
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -947,7 +985,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 "/api/resource-with-body",
                 NO_BODY,
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -987,7 +1028,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 "/api/resource-with-body/0x123/contents",
                 NO_BODY,
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 
@@ -1028,7 +1072,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                 "/api/resource-with-body/0x123-0x456/contents",
                 NO_BODY,
                 HttpStatusCode.NO_CONTENT.status(),
-                HttpEntity.EMPTY
+                HttpEntity.EMPTY.addHeader(
+                        HateosResourceMapping.X_CONTENT_TYPE_NAME,
+                        RESOURCE_TYPE_NAME
+                )
         );
     }
 


### PR DESCRIPTION
- Previously the header was missing for NO_CONTENT responses, which meant watcher events were not fired for successful DELETEs which return NO_CONTENT.