### PR TITLE
HttpXXXHandler.handleXXX UrlPath parameter added

### DIFF
--- a/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
+++ b/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
@@ -49,6 +49,14 @@ public class TestGwtTest extends GWTTestCase {
         return "test.Test";
     }
 
+
+    public void testAssertEquals() {
+        checkEquals(
+                1,
+                1
+        );
+    }
+
     public void testHateosResourceName() {
         final String name = "name123";
 
@@ -94,6 +102,7 @@ public class TestGwtTest extends GWTTestCase {
                     public Optional<TestResource3> handleOne(final BigInteger id,
                                                              final Optional<TestResource3> resource,
                                                              final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                             final UrlPath path,
                                                              final TestHateosResourceHandlerContext context) {
                         return Optional.of(
                                 TestResource3.with(

--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -118,6 +118,7 @@ public class JunitTest {
                     public Optional<TestResource3> handleOne(final BigInteger id,
                                                              final Optional<TestResource3> resource,
                                                              final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                             final UrlPath path,
                                                              final TestHateosResourceHandlerContext context) {
                         return Optional.of(
                                 TestResource3.with(

--- a/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosHttpEntityHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosHttpEntityHandler.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.collect.Range;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
@@ -28,9 +29,11 @@ public class FakeHateosHttpEntityHandler<I extends Comparable<I>, X extends Hate
     @Override
     public HttpEntity handleAll(final HttpEntity entity,
                                 final Map<HttpRequestAttribute<?>, Object> parameters,
+                                final UrlPath path,
                                 final X context) {
         HateosHttpEntityHandler.checkHttpEntity(entity);
         HateosHttpEntityHandler.checkParameters(parameters);
+        HateosHttpEntityHandler.checkPath(path);
         HateosHttpEntityHandler.checkContext(context);
 
         throw new UnsupportedOperationException();
@@ -40,10 +43,12 @@ public class FakeHateosHttpEntityHandler<I extends Comparable<I>, X extends Hate
     public HttpEntity handleMany(final Set<I> ids,
                                  final HttpEntity entity,
                                  final Map<HttpRequestAttribute<?>, Object> parameters,
+                                 final UrlPath path,
                                  final X context) {
         HateosHttpEntityHandler.checkManyIds(ids);
         HateosHttpEntityHandler.checkHttpEntity(entity);
         HateosHttpEntityHandler.checkParameters(parameters);
+        HateosHttpEntityHandler.checkPath(path);
         HateosHttpEntityHandler.checkContext(context);
 
         throw new UnsupportedOperationException();
@@ -53,10 +58,12 @@ public class FakeHateosHttpEntityHandler<I extends Comparable<I>, X extends Hate
     public HttpEntity handleOne(final I id,
                                 final HttpEntity entity,
                                 final Map<HttpRequestAttribute<?>, Object> parameters,
+                                final UrlPath path,
                                 final X context) {
         HateosHttpEntityHandler.checkId(id);
         HateosHttpEntityHandler.checkHttpEntity(entity);
         HateosHttpEntityHandler.checkParameters(parameters);
+        HateosHttpEntityHandler.checkPath(path);
         HateosHttpEntityHandler.checkContext(context);
 
         throw new UnsupportedOperationException();
@@ -65,9 +72,11 @@ public class FakeHateosHttpEntityHandler<I extends Comparable<I>, X extends Hate
     @Override
     public HttpEntity handleNone(final HttpEntity entity,
                                  final Map<HttpRequestAttribute<?>, Object> parameters,
+                                 final UrlPath path,
                                  final X context) {
         HateosHttpEntityHandler.checkHttpEntity(entity);
         HateosHttpEntityHandler.checkParameters(parameters);
+        HateosHttpEntityHandler.checkPath(path);
         HateosHttpEntityHandler.checkContext(context);
 
         throw new UnsupportedOperationException();
@@ -77,10 +86,12 @@ public class FakeHateosHttpEntityHandler<I extends Comparable<I>, X extends Hate
     public HttpEntity handleRange(final Range<I> range,
                                   final HttpEntity entity,
                                   final Map<HttpRequestAttribute<?>, Object> parameters,
+                                  final UrlPath path,
                                   final X context) {
         HateosHttpEntityHandler.checkIdRange(range);
         HateosHttpEntityHandler.checkHttpEntity(entity);
         HateosHttpEntityHandler.checkParameters(parameters);
+        HateosHttpEntityHandler.checkPath(path);
         HateosHttpEntityHandler.checkContext(context);
 
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosResourceHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosResourceHandler.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.collect.Range;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 import walkingkooka.test.Fake;
 
@@ -33,9 +34,11 @@ public class FakeHateosResourceHandler<I extends Comparable<I>, V, C, X extends 
     @Override
     public Optional<C> handleAll(final Optional<C> resource,
                                  final Map<HttpRequestAttribute<?>, Object> parameters,
+                                 final UrlPath path,
                                  final X context) {
         HateosResourceHandler.checkResource(resource);
         HateosResourceHandler.checkParameters(parameters);
+        HateosResourceHandler.checkPath(path);
         HateosResourceHandler.checkContext(context);
 
         throw new UnsupportedOperationException();
@@ -45,10 +48,12 @@ public class FakeHateosResourceHandler<I extends Comparable<I>, V, C, X extends 
     public Optional<C> handleMany(final Set<I> ids,
                                   final Optional<C> resource,
                                   final Map<HttpRequestAttribute<?>, Object> parameters,
+                                  final UrlPath path,
                                   final X context) {
         HateosResourceHandler.checkManyIds(ids);
         HateosResourceHandler.checkResource(resource);
         HateosResourceHandler.checkParameters(parameters);
+        HateosResourceHandler.checkPath(path);
         HateosResourceHandler.checkContext(context);
 
         throw new UnsupportedOperationException();
@@ -57,9 +62,11 @@ public class FakeHateosResourceHandler<I extends Comparable<I>, V, C, X extends 
     @Override
     public Optional<V> handleNone(final Optional<V> resource,
                                   final Map<HttpRequestAttribute<?>, Object> parameters,
+                                  final UrlPath path,
                                   final X context) {
         HateosResourceHandler.checkResource(resource);
         HateosResourceHandler.checkParameters(parameters);
+        HateosResourceHandler.checkPath(path);
         HateosResourceHandler.checkContext(context);
 
         throw new UnsupportedOperationException();
@@ -69,10 +76,12 @@ public class FakeHateosResourceHandler<I extends Comparable<I>, V, C, X extends 
     public Optional<V> handleOne(final I id,
                                  final Optional<V> resource,
                                  final Map<HttpRequestAttribute<?>, Object> parameters,
+                                 final UrlPath path,
                                  final X context) {
         HateosResourceHandler.checkId(id);
         HateosResourceHandler.checkResource(resource);
         HateosResourceHandler.checkParameters(parameters);
+        HateosResourceHandler.checkPath(path);
         HateosResourceHandler.checkContext(context);
 
         throw new UnsupportedOperationException();
@@ -82,10 +91,12 @@ public class FakeHateosResourceHandler<I extends Comparable<I>, V, C, X extends 
     public Optional<C> handleRange(final Range<I> range,
                                    final Optional<C> resource,
                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                   final UrlPath path,
                                    final X context) {
         HateosResourceHandler.checkIdRange(range);
         HateosResourceHandler.checkResource(resource);
         HateosResourceHandler.checkParameters(parameters);
+        HateosResourceHandler.checkPath(path);
         HateosResourceHandler.checkContext(context);
 
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHttpEntityHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHttpEntityHandler.java
@@ -19,6 +19,7 @@ package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.collect.Range;
 import walkingkooka.collect.map.Maps;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
@@ -44,6 +45,7 @@ public interface HateosHttpEntityHandler<I extends Comparable<I>, X extends Hate
      */
     HttpEntity handleAll(final HttpEntity entity,
                          final Map<HttpRequestAttribute<?>, Object> parameters,
+                         final UrlPath path,
                          final X context);
 
     /**
@@ -55,6 +57,7 @@ public interface HateosHttpEntityHandler<I extends Comparable<I>, X extends Hate
     HttpEntity handleMany(final Set<I> ids,
                           final HttpEntity entity,
                           final Map<HttpRequestAttribute<?>, Object> parameters,
+                          final UrlPath path,
                           final X context);
 
     /**
@@ -66,6 +69,7 @@ public interface HateosHttpEntityHandler<I extends Comparable<I>, X extends Hate
     HttpEntity handleOne(final I id,
                          final HttpEntity entity,
                          final Map<HttpRequestAttribute<?>, Object> parameters,
+                         final UrlPath path,
                          final X context);
 
     /**
@@ -76,6 +80,7 @@ public interface HateosHttpEntityHandler<I extends Comparable<I>, X extends Hate
      */
     HttpEntity handleNone(final HttpEntity entity,
                           final Map<HttpRequestAttribute<?>, Object> parameters,
+                          final UrlPath path,
                           final X context);
 
     /**
@@ -87,6 +92,7 @@ public interface HateosHttpEntityHandler<I extends Comparable<I>, X extends Hate
     HttpEntity handleRange(final Range<I> range,
                            final HttpEntity entity,
                            final Map<HttpRequestAttribute<?>, Object> parameters,
+                           final UrlPath path,
                            final X context);
 
     // parameter checkers...............................................................................................
@@ -124,6 +130,25 @@ public interface HateosHttpEntityHandler<I extends Comparable<I>, X extends Hate
      */
     static Map<HttpRequestAttribute<?>, Object> checkParameters(final Map<HttpRequestAttribute<?>, Object> parameters) {
         return Objects.requireNonNull(parameters, "parameters");
+    }
+
+    /**
+     * Checks that the {@link UrlPath} is present and not null.
+     */
+    static UrlPath checkPath(final UrlPath path) {
+        return Objects.requireNonNull(path, "path");
+    }
+
+    /**
+     * Checks that the {@link UrlPath} is present and not empty.
+     */
+    static UrlPath checkPathEmpty(final UrlPath path) {
+        checkPath(path);
+
+        if (false == path.equals(UrlPath.EMPTY)) {
+            throw new IllegalArgumentException("Path must not be empty");
+        }
+        return path;
     }
 
     /**

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHttpEntityHandlerTesting.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHttpEntityHandlerTesting.java
@@ -19,6 +19,7 @@ package walkingkooka.net.http.server.hateos;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.Range;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 import walkingkooka.reflect.ClassTesting2;
@@ -40,13 +41,14 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
         TreePrintableTesting,
         TypeNameTesting<H> {
 
-// handleAll.......................................................................................................
+    // handleAll........................................................................................................
 
     @Test
     default void testHandleAllWithNullEntityFails() {
         this.handleAllFails(
                 null,
                 HateosHttpEntityHandler.NO_PARAMETERS,
+                this.path(),
                 this.context(),
                 NullPointerException.class
         );
@@ -56,6 +58,18 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     default void testHandleAllWithNullParametersFails() {
         this.handleAllFails(
                 this.entity(),
+                null,
+                this.path(),
+                this.context(),
+                NullPointerException.class
+        );
+    }
+
+    @Test
+    default void testHandleAllWithNullPathFails() {
+        this.handleAllFails(
+                this.entity(),
+                this.parameters(),
                 null,
                 this.context(),
                 NullPointerException.class
@@ -67,6 +81,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
         this.handleAllFails(
                 this.entity(),
                 this.parameters(),
+                this.path(),
                 null,
                 NullPointerException.class
         );
@@ -74,12 +89,14 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
 
     default <T extends Throwable> T handleAllFails(final HttpEntity entity,
                                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                   final UrlPath path,
                                                    final X context,
                                                    final Class<T> thrown) {
         return this.handleAllFails(
                 this.createHandler(),
                 entity,
                 parameters,
+                path,
                 context,
                 thrown
         );
@@ -88,6 +105,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     default <T extends Throwable> T handleAllFails(final HateosHttpEntityHandler<I, X> handler,
                                                    final HttpEntity entity,
                                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                   final UrlPath path,
                                                    final X context,
                                                    final Class<T> thrown) {
         return assertThrows(
@@ -95,6 +113,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 () -> handler.handleAll(
                         entity,
                         parameters,
+                        path,
                         context
                 )
         );
@@ -102,12 +121,14 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
 
     default void handleAllAndCheck(final HttpEntity entity,
                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                   final UrlPath path,
                                    final X context,
                                    final HttpEntity expected) {
         this.handleAllAndCheck(
                 this.createHandler(),
                 entity,
                 parameters,
+                path,
                 context,
                 expected
         );
@@ -116,6 +137,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     default void handleAllAndCheck(final HateosHttpEntityHandler<I, X> handler,
                                    final HttpEntity entity,
                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                   final UrlPath path,
                                    final X context,
                                    final HttpEntity expected) {
         this.checkEquals(
@@ -123,6 +145,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 handler.handleAll(
                         entity,
                         parameters,
+                        path,
                         context
                 )
         );
@@ -136,6 +159,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 this.manyIds(),
                 null,
                 HateosHttpEntityHandler.NO_PARAMETERS,
+                this.path(),
                 this.context(),
                 NullPointerException.class
         );
@@ -146,6 +170,19 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
         this.handleManyFails(
                 this.manyIds(),
                 this.entity(),
+                null,
+                this.path(),
+                this.context(),
+                NullPointerException.class
+        );
+    }
+
+    @Test
+    default void testHandleManyWithNullPathFails() {
+        this.handleManyFails(
+                this.manyIds(),
+                this.entity(),
+                this.parameters(),
                 null,
                 this.context(),
                 NullPointerException.class
@@ -158,6 +195,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 this.manyIds(),
                 this.entity(),
                 this.parameters(),
+                this.path(),
                 null,
                 NullPointerException.class
         );
@@ -166,6 +204,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     default <T extends Throwable> T handleManyFails(final Set<I> ids,
                                                     final HttpEntity entity,
                                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                    final UrlPath path,
                                                     final X context,
                                                     final Class<T> thrown) {
         return this.handleManyFails(
@@ -173,6 +212,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 ids,
                 entity,
                 parameters,
+                path,
                 context,
                 thrown
         );
@@ -182,6 +222,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                                                     final Set<I> ids,
                                                     final HttpEntity entity,
                                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                    final UrlPath path,
                                                     final X context,
                                                     final Class<T> thrown) {
         return assertThrows(
@@ -190,6 +231,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                         ids,
                         entity,
                         parameters,
+                        path,
                         context
                 )
         );
@@ -198,6 +240,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     default void handleManyAndCheck(final Set<I> ids,
                                     final HttpEntity entity,
                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                    final UrlPath path,
                                     final X context,
                                     final HttpEntity expected) {
         this.handleManyAndCheck(
@@ -205,6 +248,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 ids,
                 entity,
                 parameters,
+                path,
                 context,
                 expected
         );
@@ -214,6 +258,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                                     final Set<I> ids,
                                     final HttpEntity entity,
                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                    final UrlPath path,
                                     final X context,
                                     final HttpEntity expected) {
         this.checkEquals(
@@ -222,18 +267,20 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                         ids,
                         entity,
                         parameters,
+                        path,
                         context
                 )
         );
     }
 
-// handleNone.......................................................................................................
+    // handleNone.......................................................................................................
 
     @Test
     default void testHandleNoneWithNullEntityFails() {
         this.handleNoneFails(
                 null,
-                HateosHttpEntityHandler.NO_PARAMETERS,
+                this.parameters(),
+                this.path(),
                 this.context(),
                 NullPointerException.class
         );
@@ -243,6 +290,18 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     default void testHandleNoneWithNullParametersFails() {
         this.handleNoneFails(
                 this.entity(),
+                null,
+                this.path(),
+                this.context(),
+                NullPointerException.class
+        );
+    }
+
+    @Test
+    default void testHandleNoneWithNullPathFails() {
+        this.handleNoneFails(
+                this.entity(),
+                this.parameters(),
                 null,
                 this.context(),
                 NullPointerException.class
@@ -254,6 +313,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
         this.handleNoneFails(
                 this.entity(),
                 this.parameters(),
+                this.path(),
                 null,
                 NullPointerException.class
         );
@@ -261,12 +321,14 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
 
     default <T extends Throwable> T handleNoneFails(final HttpEntity entity,
                                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                    final UrlPath path,
                                                     final X context,
                                                     final Class<T> thrown) {
         return this.handleNoneFails(
                 this.createHandler(),
                 entity,
                 parameters,
+                path,
                 context,
                 thrown
         );
@@ -275,6 +337,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     default <T extends Throwable> T handleNoneFails(final HateosHttpEntityHandler<I, X> handler,
                                                     final HttpEntity entity,
                                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                    final UrlPath path,
                                                     final X context,
                                                     final Class<T> thrown) {
         return assertThrows(
@@ -282,6 +345,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 () -> handler.handleNone(
                         entity,
                         parameters,
+                        path,
                         context
                 )
         );
@@ -289,12 +353,14 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
 
     default void handleNoneAndCheck(final HttpEntity entity,
                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                    final UrlPath path,
                                     final X context,
                                     final HttpEntity expected) {
         this.handleNoneAndCheck(
                 this.createHandler(),
                 entity,
                 parameters,
+                path,
                 context,
                 expected
         );
@@ -303,6 +369,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     default void handleNoneAndCheck(final HateosHttpEntityHandler<I, X> handler,
                                     final HttpEntity entity,
                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                    final UrlPath path,
                                     final X context,
                                     final HttpEntity expected) {
         this.checkEquals(
@@ -310,19 +377,21 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 handler.handleNone(
                         entity,
                         parameters,
+                        path,
                         context
                 )
         );
     }
 
-// handleOne........................................................................................................
+    // handleOne........................................................................................................
 
     @Test
     default void testHandleOneWithNullEntityFails() {
         this.handleOneFails(
                 this.id(),
                 null,
-                HateosHttpEntityHandler.NO_PARAMETERS,
+                this.parameters(),
+                this.path(),
                 this.context(),
                 NullPointerException.class
         );
@@ -333,6 +402,19 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
         this.handleOneFails(
                 this.id(),
                 this.entity(),
+                null,
+                this.path(),
+                this.context(),
+                NullPointerException.class
+        );
+    }
+
+    @Test
+    default void testHandleOneWithNullPathFails() {
+        this.handleOneFails(
+                this.id(),
+                this.entity(),
+                this.parameters(),
                 null,
                 this.context(),
                 NullPointerException.class
@@ -345,6 +427,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 this.id(),
                 this.entity(),
                 this.parameters(),
+                this.path(),
                 null,
                 NullPointerException.class
         );
@@ -353,6 +436,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     default <T extends Throwable> T handleOneFails(final I id,
                                                    final HttpEntity entity,
                                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                   final UrlPath path,
                                                    final X context,
                                                    final Class<T> thrown) {
         return this.handleOneFails(
@@ -360,6 +444,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 id,
                 entity,
                 parameters,
+                path,
                 context,
                 thrown
         );
@@ -369,6 +454,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                                                    final I id,
                                                    final HttpEntity entity,
                                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                   final UrlPath path,
                                                    final X context,
                                                    final Class<T> thrown) {
         return assertThrows(
@@ -377,6 +463,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                         id,
                         entity,
                         parameters,
+                        path,
                         context
                 )
         );
@@ -385,6 +472,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     default void handleOneAndCheck(final I id,
                                    final HttpEntity entity,
                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                   final UrlPath path,
                                    final X context,
                                    final HttpEntity expected) {
         this.handleOneAndCheck(
@@ -392,6 +480,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 id,
                 entity,
                 parameters,
+                path,
                 context,
                 expected
         );
@@ -401,6 +490,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                                    final I id,
                                    final HttpEntity entity,
                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                   final UrlPath path,
                                    final X context,
                                    final HttpEntity expected) {
         this.checkEquals(
@@ -409,19 +499,21 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                         id,
                         entity,
                         parameters,
+                        path,
                         context
                 )
         );
     }
 
-// handleRange......................................................................................................
+    // handleRange......................................................................................................
 
     @Test
     default void testHandleRangeWithNullIdsFails() {
         this.handleRangeFails(
                 null,
                 this.entity(),
-                HateosHttpEntityHandler.NO_PARAMETERS,
+                this.parameters(),
+                this.path(),
                 this.context(),
                 NullPointerException.class
         );
@@ -432,7 +524,8 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
         this.handleRangeFails(
                 this.range(),
                 null,
-                HateosHttpEntityHandler.NO_PARAMETERS,
+                this.parameters(),
+                this.path(),
                 this.context(),
                 NullPointerException.class
         );
@@ -443,6 +536,19 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
         this.handleRangeFails(
                 this.range(),
                 this.entity(),
+                null,
+                this.path(),
+                this.context(),
+                NullPointerException.class
+        );
+    }
+
+    @Test
+    default void testHandleRangeWithNullPathFails() {
+        this.handleRangeFails(
+                this.range(),
+                this.entity(),
+                this.parameters(),
                 null,
                 this.context(),
                 NullPointerException.class
@@ -455,6 +561,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 this.range(),
                 this.entity(),
                 this.parameters(),
+                this.path(),
                 null,
                 NullPointerException.class
         );
@@ -463,6 +570,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     default <T extends Throwable> T handleRangeFails(final Range<I> ids,
                                                      final HttpEntity entity,
                                                      final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                     final UrlPath path,
                                                      final X context,
                                                      final Class<T> thrown) {
         return this.handleRangeFails(
@@ -470,6 +578,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 ids,
                 entity,
                 parameters,
+                path,
                 context,
                 thrown
         );
@@ -479,6 +588,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                                                      final Range<I> ids,
                                                      final HttpEntity entity,
                                                      final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                     final UrlPath path,
                                                      final X context,
                                                      final Class<T> thrown) {
         return assertThrows(
@@ -487,6 +597,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                         ids,
                         entity,
                         parameters,
+                        path,
                         context
                 )
         );
@@ -495,6 +606,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     default void handleRangeAndCheck(final Range<I> ids,
                                      final HttpEntity entity,
                                      final Map<HttpRequestAttribute<?>, Object> parameters,
+                                     final UrlPath path,
                                      final X context,
                                      final HttpEntity expected) {
         this.handleRangeAndCheck(
@@ -502,6 +614,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                 ids,
                 entity,
                 parameters,
+                path,
                 context,
                 expected
         );
@@ -511,6 +624,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                                      final Range<I> ids,
                                      final HttpEntity entity,
                                      final Map<HttpRequestAttribute<?>, Object> parameters,
+                                     final UrlPath path,
                                      final X context,
                                      final HttpEntity expected) {
         this.checkEquals(
@@ -519,6 +633,7 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
                         ids,
                         entity,
                         parameters,
+                        path,
                         context
                 )
         );
@@ -537,6 +652,8 @@ public interface HateosHttpEntityHandlerTesting<H extends HateosHttpEntityHandle
     HttpEntity entity();
 
     Map<HttpRequestAttribute<?>, Object> parameters();
+
+    UrlPath path();
 
     X context();
 }

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceHandler.java
@@ -19,6 +19,7 @@ package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.collect.Range;
 import walkingkooka.collect.map.Maps;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
 import java.util.Map;
@@ -47,6 +48,7 @@ public interface HateosResourceHandler<I extends Comparable<I>, V, C, X extends 
      */
     Optional<C> handleAll(final Optional<C> resource,
                           final Map<HttpRequestAttribute<?>, Object> parameters,
+                          final UrlPath path,
                           final X context);
 
     /**
@@ -58,6 +60,7 @@ public interface HateosResourceHandler<I extends Comparable<I>, V, C, X extends 
     Optional<C> handleMany(final Set<I> ids,
                            final Optional<C> resource,
                            final Map<HttpRequestAttribute<?>, Object> parameters,
+                           final UrlPath path,
                            final X context);
 
     /**
@@ -69,6 +72,7 @@ public interface HateosResourceHandler<I extends Comparable<I>, V, C, X extends 
     Optional<V> handleOne(final I id,
                           final Optional<V> resource,
                           final Map<HttpRequestAttribute<?>, Object> parameters,
+                          final UrlPath path,
                           final X context);
 
     /**
@@ -79,6 +83,7 @@ public interface HateosResourceHandler<I extends Comparable<I>, V, C, X extends 
      */
     Optional<V> handleNone(final Optional<V> resource,
                            final Map<HttpRequestAttribute<?>, Object> parameters,
+                           final UrlPath path,
                            final X context);
 
     /**
@@ -90,6 +95,7 @@ public interface HateosResourceHandler<I extends Comparable<I>, V, C, X extends 
     Optional<C> handleRange(final Range<I> range,
                             final Optional<C> resource,
                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                            final UrlPath path,
                             final X context);
 
     // parameter checkers...............................................................................................
@@ -146,6 +152,25 @@ public interface HateosResourceHandler<I extends Comparable<I>, V, C, X extends 
      */
     static Map<HttpRequestAttribute<?>, Object> checkParameters(final Map<HttpRequestAttribute<?>, Object> parameters) {
         return Objects.requireNonNull(parameters, "parameters");
+    }
+
+    /**
+     * Checks that the {@link UrlPath} is present and not null.
+     */
+    static UrlPath checkPath(final UrlPath path) {
+        return Objects.requireNonNull(path, "path");
+    }
+
+    /**
+     * Checks that the {@link UrlPath} is present and not empty.
+     */
+    static UrlPath checkPathEmpty(final UrlPath path) {
+        checkPath(path);
+
+        if (false == path.equals(UrlPath.EMPTY)) {
+            throw new IllegalArgumentException("Path must not be empty");
+        }
+        return path;
     }
 
     /**

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceHandlerTesting.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceHandlerTesting.java
@@ -19,6 +19,7 @@ package walkingkooka.net.http.server.hateos;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.Range;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.TypeNameTesting;
@@ -42,13 +43,14 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
         TreePrintableTesting,
         TypeNameTesting<H> {
 
-    // handleAll.......................................................................................................
+    // handleAll........................................................................................................
 
     @Test
     default void testHandleAllNullResourceFails() {
         this.handleAllFails(
                 null,
                 this.parameters(),
+                this.path(),
                 this.context(),
                 NullPointerException.class);
     }
@@ -57,6 +59,17 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     default void testHandleAllNullParametersFails() {
         this.handleAllFails(
                 this.collectionResource(),
+                null,
+                this.path(),
+                this.context(),
+                NullPointerException.class);
+    }
+
+    @Test
+    default void testHandleAllNullPathFails() {
+        this.handleAllFails(
+                this.collectionResource(),
+                this.parameters(),
                 null,
                 this.context(),
                 NullPointerException.class);
@@ -67,18 +80,21 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
         this.handleAllFails(
                 this.collectionResource(),
                 this.parameters(),
+                this.path(),
                 null,
                 NullPointerException.class);
     }
 
     default <T extends Throwable> T handleAllFails(final Optional<C> resource,
                                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                   final UrlPath path,
                                                    final X context,
                                                    final Class<T> thrown) {
         return this.handleAllFails(
                 this.createHandler(),
                 resource,
                 parameters,
+                path,
                 context,
                 thrown
         );
@@ -87,6 +103,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     default <T extends Throwable> T handleAllFails(final HateosResourceHandler<I, V, C, X> handler,
                                                    final Optional<C> resource,
                                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                   final UrlPath path,
                                                    final X context,
                                                    final Class<T> thrown) {
         return assertThrows(
@@ -94,6 +111,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                     handler.handleAll(
                             resource,
                             parameters,
+                            path,
                             context
                     );
                 });
@@ -101,12 +119,14 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
 
     default void handleAllAndCheck(final Optional<C> resource,
                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                   final UrlPath path,
                                    final X context,
                                    final Optional<C> expected) {
         this.handleAllAndCheck(
                 this.createHandler(),
                 resource,
                 parameters,
+                path,
                 context,
                 expected
         );
@@ -115,6 +135,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     default void handleAllAndCheck(final HateosResourceHandler<I, V, C, X> handler,
                                    final Optional<C> resource,
                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                   final UrlPath path,
                                    final X context,
                                    final Optional<C> expected) {
         this.checkEquals(
@@ -122,6 +143,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 handler.handleAll(
                         resource,
                         parameters,
+                        path,
                         context
                 )
         );
@@ -135,6 +157,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 null,
                 this.collectionResource(),
                 this.parameters(),
+                this.path(),
                 this.context(),
                 NullPointerException.class
         );
@@ -146,17 +169,30 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 this.manyIds(),
                 null,
                 this.parameters(),
+                this.path(),
                 this.context(),
                 NullPointerException.class
         );
     }
-
 
     @Test
     default void testHandleManyNullParametersFails() {
         this.handleManyFails(
                 this.manyIds(),
                 this.collectionResource(),
+                null,
+                this.path(),
+                this.context(),
+                NullPointerException.class
+        );
+    }
+
+    @Test
+    default void testHandleManyNullPathFails() {
+        this.handleManyFails(
+                this.manyIds(),
+                this.collectionResource(),
+                this.parameters(),
                 null,
                 this.context(),
                 NullPointerException.class
@@ -169,6 +205,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 this.manyIds(),
                 this.collectionResource(),
                 this.parameters(),
+                this.path(),
                 null,
                 NullPointerException.class
         );
@@ -177,6 +214,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     default <T extends Throwable> T handleManyFails(final Set<I> ids,
                                                     final Optional<C> resource,
                                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                    final UrlPath path,
                                                     final X context,
                                                     final Class<T> thrown) {
         return this.handleManyFails(
@@ -184,6 +222,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 ids,
                 resource,
                 parameters,
+                path,
                 context,
                 thrown
         );
@@ -193,6 +232,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                                                     final Set<I> ids,
                                                     final Optional<C> resource,
                                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                    final UrlPath path,
                                                     final X context,
                                                     final Class<T> thrown) {
         return assertThrows(
@@ -202,6 +242,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                             ids,
                             resource,
                             parameters,
+                            path,
                             context
                     );
                 });
@@ -210,6 +251,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     default void handleManyAndCheck(final Set<I> ids,
                                     final Optional<C> resource,
                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                    final UrlPath path,
                                     final X context,
                                     final Optional<C> expected) {
         this.handleManyAndCheck(
@@ -217,6 +259,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 ids,
                 resource,
                 parameters,
+                path,
                 context,
                 expected
         );
@@ -226,6 +269,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                                     final Set<I> ids,
                                     final Optional<C> resource,
                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                    final UrlPath path,
                                     final X context,
                                     final Optional<C> expected) {
         this.checkEquals(
@@ -234,6 +278,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                         ids,
                         resource,
                         parameters,
+                        path,
                         context
                 )
         );
@@ -246,6 +291,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
         this.handleNoneFails(
                 null,
                 this.parameters(),
+                this.path(),
                 this.context(),
                 NullPointerException.class
         );
@@ -255,6 +301,18 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     default void testHandleNoneNullParametersFails() {
         this.handleNoneFails(
                 this.resource(),
+                null,
+                this.path(),
+                this.context(),
+                NullPointerException.class
+        );
+    }
+
+    @Test
+    default void testHandleNoneNullPathFails() {
+        this.handleNoneFails(
+                this.resource(),
+                this.parameters(),
                 null,
                 this.context(),
                 NullPointerException.class
@@ -266,6 +324,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
         this.handleNoneFails(
                 this.resource(),
                 this.parameters(),
+                this.path(),
                 null,
                 NullPointerException.class
         );
@@ -273,12 +332,14 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
 
     default <T extends Throwable> T handleNoneFails(final Optional<V> resource,
                                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                    final UrlPath path,
                                                     final X context,
                                                     final Class<T> thrown) {
         return this.handleNoneFails(
                 this.createHandler(),
                 resource,
                 parameters,
+                path,
                 context,
                 thrown
         );
@@ -287,6 +348,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     default <T extends Throwable> T handleNoneFails(final HateosResourceHandler<I, V, C, X> handler,
                                                     final Optional<V> resource,
                                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                    final UrlPath path,
                                                     final X context,
                                                     final Class<T> thrown) {
         return assertThrows(
@@ -294,6 +356,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                     handler.handleNone(
                             resource,
                             parameters,
+                            path,
                             context
                     );
                 }
@@ -302,12 +365,14 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
 
     default void handleNoneAndCheck(final Optional<V> resource,
                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                    final UrlPath path,
                                     final X context,
                                     final Optional<V> expected) {
         this.handleNoneAndCheck(
                 this.createHandler(),
                 resource,
                 parameters,
+                path,
                 context,
                 expected
         );
@@ -316,6 +381,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     default void handleNoneAndCheck(final HateosResourceHandler<I, V, C, X> handler,
                                     final Optional<V> resource,
                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                    final UrlPath path,
                                     final X context,
                                     final Optional<V> expected) {
         this.checkEquals(
@@ -323,6 +389,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 handler.handleNone(
                         resource,
                         parameters,
+                        path,
                         context
                 )
         );
@@ -336,6 +403,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 null,
                 this.resource(),
                 this.parameters(),
+                this.path(),
                 this.context(),
                 NullPointerException.class);
     }
@@ -346,6 +414,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 this.id(),
                 null,
                 this.parameters(),
+                this.path(),
                 this.context(),
                 NullPointerException.class);
     }
@@ -355,6 +424,19 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
         this.handleOneFails(
                 this.id(),
                 this.resource(),
+                null,
+                this.path(),
+                this.context(),
+                NullPointerException.class
+        );
+    }
+
+    @Test
+    default void testHandleOneNullPathFails() {
+        this.handleOneFails(
+                this.id(),
+                this.resource(),
+                this.parameters(),
                 null,
                 this.context(),
                 NullPointerException.class
@@ -367,6 +449,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 this.id(),
                 this.resource(),
                 this.parameters(),
+                this.path(),
                 null,
                 NullPointerException.class
         );
@@ -375,6 +458,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     default <T extends Throwable> T handleOneFails(final I id,
                                                    final Optional<V> resource,
                                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                   final UrlPath path,
                                                    final X context,
                                                    final Class<T> thrown) {
         return this.handleOneFails(
@@ -382,6 +466,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 id,
                 resource,
                 parameters,
+                path,
                 context,
                 thrown
         );
@@ -391,6 +476,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                                                    final I id,
                                                    final Optional<V> resource,
                                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                   final UrlPath path,
                                                    final X context,
                                                    final Class<T> thrown) {
         return assertThrows(
@@ -400,6 +486,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                             id,
                             resource,
                             parameters,
+                            path,
                             context
                     );
                 });
@@ -408,6 +495,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     default void handleOneAndCheck(final I id,
                                    final Optional<V> resource,
                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                   final UrlPath path,
                                    final X context,
                                    final Optional<V> expected) {
         this.handleOneAndCheck(
@@ -415,6 +503,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 id,
                 resource,
                 parameters,
+                path,
                 context,
                 expected
         );
@@ -424,6 +513,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                                    final I id,
                                    final Optional<V> resource,
                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                   final UrlPath path,
                                    final X context,
                                    final Optional<V> expected) {
         this.checkEquals(
@@ -432,6 +522,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                         id,
                         resource,
                         parameters,
+                        path,
                         context
                 )
         );
@@ -445,6 +536,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 null,
                 this.collectionResource(),
                 this.parameters(),
+                this.path(),
                 this.context(),
                 NullPointerException.class
         );
@@ -456,6 +548,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 this.range(),
                 null,
                 this.parameters(),
+                this.path(),
                 this.context(),
                 NullPointerException.class
         );
@@ -466,6 +559,19 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
         this.handleRangeFails(
                 this.range(),
                 this.collectionResource(),
+                null,
+                this.path(),
+                this.context(),
+                NullPointerException.class
+        );
+    }
+
+    @Test
+    default void testHandleRangeNullPathFails() {
+        this.handleRangeFails(
+                this.range(),
+                this.collectionResource(),
+                this.parameters(),
                 null,
                 this.context(),
                 NullPointerException.class
@@ -478,6 +584,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 this.range(),
                 this.collectionResource(),
                 this.parameters(),
+                this.path(),
                 null,
                 NullPointerException.class
         );
@@ -486,6 +593,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     default <T extends Throwable> T handleRangeFails(final Range<I> range,
                                                      final Optional<C> resource,
                                                      final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                     final UrlPath path,
                                                      final X context,
                                                      final Class<T> thrown) {
         return this.handleRangeFails(
@@ -493,6 +601,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 range,
                 resource,
                 parameters,
+                path,
                 context,
                 thrown
         );
@@ -502,6 +611,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                                                      final Range<I> range,
                                                      final Optional<C> resource,
                                                      final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                     final UrlPath path,
                                                      final X context,
                                                      final Class<T> thrown) {
         return assertThrows(
@@ -510,7 +620,9 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                             range,
                             resource,
                             parameters,
-                            context);
+                            path,
+                            context
+                    );
                 }
         );
     }
@@ -518,6 +630,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     default void handleRangeAndCheck(final Range<I> range,
                                      final Optional<C> resource,
                                      final Map<HttpRequestAttribute<?>, Object> parameters,
+                                     final UrlPath path,
                                      final X context,
                                      final Optional<C> expected) {
         this.handleRangeAndCheck(
@@ -525,6 +638,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                 range,
                 resource,
                 parameters,
+                path,
                 context,
                 expected
         );
@@ -534,6 +648,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                                      final Range<I> range,
                                      final Optional<C> resource,
                                      final Map<HttpRequestAttribute<?>, Object> parameters,
+                                     final UrlPath path,
                                      final X context,
                                      final Optional<C> expected) {
         this.checkEquals(
@@ -542,6 +657,7 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
                         range,
                         resource,
                         parameters,
+                        path,
                         context
                 )
         );
@@ -562,6 +678,8 @@ public interface HateosResourceHandlerTesting<H extends HateosResourceHandler<I,
     Optional<C> collectionResource();
 
     Map<HttpRequestAttribute<?>, Object> parameters();
+
+    UrlPath path();
 
     X context();
 

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMapping.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMapping.java
@@ -233,8 +233,8 @@ public final class HateosResourceMapping<I extends Comparable<I>, V, C, H extend
     /**
      * The type used to marshall the resource for
      * <ol>
-     * <li>{@link HateosResourceHandler#handleNone(Optional, Map, HateosResourceHandlerContext)},</li>
-     * <li>{@link HateosResourceHandler#handleOne(Comparable, Optional, Map, HateosResourceHandlerContext)},</li>
+     * <li>{@link HateosResourceHandler#handleNone(Optional, Map, UrlPath, HateosResourceHandlerContext)},</li>
+     * <li>{@link HateosResourceHandler#handleOne(Comparable, Optional, Map, UrlPath, HateosResourceHandlerContext)},</li>
      * </ol>
      */
     final Class<V> valueType;
@@ -242,9 +242,9 @@ public final class HateosResourceMapping<I extends Comparable<I>, V, C, H extend
     /**
      * The type used to marshall the resource for
      * <ol>
-     * <li>{@link HateosResourceHandler#handleMany(Set, Optional, Map, HateosResourceHandlerContext)},</li>
-     * <li>{@link HateosResourceHandler#handleRange(Range, Optional, Map, HateosResourceHandlerContext)},</li>
-     * <li>{@link HateosResourceHandler#handleAll(Optional, Map, HateosResourceHandlerContext)},</li>
+     * <li>{@link HateosResourceHandler#handleMany(Set, Optional, Map, UrlPath, HateosResourceHandlerContext)},</li>
+     * <li>{@link HateosResourceHandler#handleRange(Range, Optional, Map, UrlPath, HateosResourceHandlerContext)},</li>
+     * <li>{@link HateosResourceHandler#handleAll(Optional, Map, UrlPath, HateosResourceHandlerContext)},</li>
      * </ol>
      */
     final Class<C> collectionType;

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingHandler.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.net.http.server.hateos;
 
+import walkingkooka.net.UrlPath;
+
 /**
  * A simple wrapper to hold either a {@link HateosHttpEntityHandler} or {@link HateosResourceHandler}
  */
@@ -44,5 +46,6 @@ abstract class HateosResourceMappingHandler {
     abstract void handle(final HateosResourceMappingRouterHttpHandlerRequest request,
                          final HateosResourceMapping<?, ?, ?, ?, ?> mapping,
                          final HateosResourceSelection<?> selection,
+                         final UrlPath path,
                          final HateosResourceHandlerContext context);
 }

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingHandlerHateosHttpEntityHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingHandlerHateosHttpEntityHandler.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.net.http.server.hateos;
 
+import walkingkooka.net.UrlPath;
+
 import java.util.Objects;
 
 final class HateosResourceMappingHandlerHateosHttpEntityHandler extends HateosResourceMappingHandler {
@@ -35,10 +37,12 @@ final class HateosResourceMappingHandlerHateosHttpEntityHandler extends HateosRe
     void handle(final HateosResourceMappingRouterHttpHandlerRequest request,
                 final HateosResourceMapping<?, ?, ?, ?, ?> mapping,
                 final HateosResourceSelection<?> selection,
+                final UrlPath path,
                 final HateosResourceHandlerContext context) {
         request.handleHateosHttpEntityHandler(
                 this.handler,
                 selection,
+                path,
                 context
         );
     }

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingHandlerHateosResourceHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingHandlerHateosResourceHandler.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.net.http.server.hateos;
 
+import walkingkooka.net.UrlPath;
+
 import java.util.Objects;
 
 final class HateosResourceMappingHandlerHateosResourceHandler extends HateosResourceMappingHandler {
@@ -35,11 +37,13 @@ final class HateosResourceMappingHandlerHateosResourceHandler extends HateosReso
     void handle(final HateosResourceMappingRouterHttpHandlerRequest request,
                 final HateosResourceMapping<?, ?, ?, ?, ?> mapping,
                 final HateosResourceSelection<?> selection,
+                final UrlPath path,
                 final HateosResourceHandlerContext context) {
         request.handleHateosResourceHandler(
                 this.handler,
                 mapping,
                 selection,
+                path,
                 context
         );
     }

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelection.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelection.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.collect.Range;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpStatusCode;
 import walkingkooka.net.http.server.HttpRequestAttribute;
@@ -139,11 +140,13 @@ public abstract class HateosResourceSelection<I extends Comparable<I>> {
     abstract HttpEntity handleHateosHttpEntityHandler(final HateosHttpEntityHandler<I, ?> handler,
                                                       final HttpEntity entity,
                                                       final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                      final UrlPath path,
                                                       final HateosResourceHandlerContext context);
 
     abstract Optional<?> handleHateosResourceHandler(final HateosResourceHandler<I, ?, ?, ?> handler,
                                                      final Optional<?> resource,
                                                      final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                     final UrlPath path,
                                                      final HateosResourceHandlerContext context);
 
     @Override

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelectionAll.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelectionAll.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.Cast;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
@@ -40,10 +41,12 @@ final class HateosResourceSelectionAll<I extends Comparable<I>> extends HateosRe
     HttpEntity handleHateosHttpEntityHandler(final HateosHttpEntityHandler<I, ?> handler,
                                              final HttpEntity entity,
                                              final Map<HttpRequestAttribute<?>, Object> parameters,
+                                             final UrlPath path,
                                              final HateosResourceHandlerContext context) {
         return handler.handleAll(
                 entity,
                 parameters,
+                path,
                 Cast.to(context)
         );
     }
@@ -52,10 +55,12 @@ final class HateosResourceSelectionAll<I extends Comparable<I>> extends HateosRe
     Optional<?> handleHateosResourceHandler(final HateosResourceHandler<I, ?, ?, ?> handler,
                                             final Optional<?> resource,
                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                            final UrlPath path,
                                             final HateosResourceHandlerContext context) {
         return handler.handleAll(
                 Cast.to(resource),
                 parameters,
+                path,
                 Cast.to(context)
         );
     }

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelectionMany.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelectionMany.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.Cast;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
@@ -41,11 +42,13 @@ final class HateosResourceSelectionMany<I extends Comparable<I>> extends HateosR
     HttpEntity handleHateosHttpEntityHandler(final HateosHttpEntityHandler<I, ?> handler,
                                              final HttpEntity entity,
                                              final Map<HttpRequestAttribute<?>, Object> parameters,
+                                             final UrlPath path,
                                              final HateosResourceHandlerContext context) {
         return handler.handleMany(
                 this.value(),
                 entity,
                 parameters,
+                path,
                 Cast.to(context)
         );
     }
@@ -54,11 +57,13 @@ final class HateosResourceSelectionMany<I extends Comparable<I>> extends HateosR
     Optional<?> handleHateosResourceHandler(final HateosResourceHandler<I, ?, ?, ?> handler,
                                             final Optional<?> resource,
                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                            final UrlPath path,
                                             final HateosResourceHandlerContext context) {
         return handler.handleMany(
                 this.value(),
                 Cast.to(resource),
                 parameters,
+                path,
                 Cast.to(context)
         );
     }

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelectionNone.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelectionNone.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.Cast;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
@@ -40,10 +41,12 @@ final class HateosResourceSelectionNone<I extends Comparable<I>> extends HateosR
     HttpEntity handleHateosHttpEntityHandler(final HateosHttpEntityHandler<I, ?> handler,
                                              final HttpEntity entity,
                                              final Map<HttpRequestAttribute<?>, Object> parameters,
+                                             final UrlPath path,
                                              final HateosResourceHandlerContext context) {
         return handler.handleNone(
                 entity,
                 parameters,
+                path,
                 Cast.to(context)
         );
     }
@@ -52,10 +55,12 @@ final class HateosResourceSelectionNone<I extends Comparable<I>> extends HateosR
     Optional<?> handleHateosResourceHandler(final HateosResourceHandler<I, ?, ?, ?> handler,
                                             final Optional<?> resource,
                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                            final UrlPath path,
                                             final HateosResourceHandlerContext context) {
         return handler.handleNone(
                 Cast.to(resource),
                 parameters,
+                path,
                 Cast.to(context)
         );
     }

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelectionOne.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelectionOne.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.Cast;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
@@ -40,11 +41,13 @@ final class HateosResourceSelectionOne<I extends Comparable<I>> extends HateosRe
     HttpEntity handleHateosHttpEntityHandler(final HateosHttpEntityHandler<I, ?> handler,
                                              final HttpEntity entity,
                                              final Map<HttpRequestAttribute<?>, Object> parameters,
+                                             final UrlPath path,
                                              final HateosResourceHandlerContext context) {
         return handler.handleOne(
                 this.value(),
                 entity,
                 parameters,
+                path,
                 Cast.to(context)
         );
     }
@@ -53,11 +56,13 @@ final class HateosResourceSelectionOne<I extends Comparable<I>> extends HateosRe
     Optional<?> handleHateosResourceHandler(final HateosResourceHandler<I, ?, ?, ?> handler,
                                             final Optional<?> resource,
                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                            final UrlPath path,
                                             final HateosResourceHandlerContext context) {
         return handler.handleOne(
                 this.value(),
                 Cast.to(resource),
                 parameters,
+                path,
                 Cast.to(context)
         );
     }

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelectionRange.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceSelectionRange.java
@@ -19,6 +19,7 @@ package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.Cast;
 import walkingkooka.collect.Range;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
@@ -41,11 +42,13 @@ final class HateosResourceSelectionRange<I extends Comparable<I>> extends Hateos
     HttpEntity handleHateosHttpEntityHandler(final HateosHttpEntityHandler<I, ?> handler,
                                              final HttpEntity entity,
                                              final Map<HttpRequestAttribute<?>, Object> parameters,
+                                             final UrlPath path,
                                              final HateosResourceHandlerContext context) {
         return handler.handleRange(
                 this.value(),
                 entity,
                 parameters,
+                path,
                 Cast.to(context)
         );
     }
@@ -54,11 +57,13 @@ final class HateosResourceSelectionRange<I extends Comparable<I>> extends Hateos
     Optional<?> handleHateosResourceHandler(final HateosResourceHandler<I, ?, ?, ?> handler,
                                             final Optional<?> resource,
                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                            final UrlPath path,
                                             final HateosResourceHandlerContext context) {
         return handler.handleRange(
                 this.value(),
                 Cast.to(resource),
                 parameters,
+                path,
                 Cast.to(context)
         );
     }

--- a/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosHttpEntityHandlerHandleAll.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosHttpEntityHandlerHandleAll.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.net.http.server.hateos;
 
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
@@ -27,9 +28,11 @@ public interface UnsupportedHateosHttpEntityHandlerHandleAll<I extends Comparabl
     @Override
     default HttpEntity handleAll(final HttpEntity entity,
                                  final Map<HttpRequestAttribute<?>, Object> parameters,
+                                 final UrlPath path,
                                  final X context) {
         HateosHttpEntityHandler.checkHttpEntity(entity);
         HateosHttpEntityHandler.checkParameters(parameters);
+        HateosHttpEntityHandler.checkPath(path);
         HateosHttpEntityHandler.checkContext(context);
 
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosHttpEntityHandlerHandleMany.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosHttpEntityHandlerHandleMany.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.net.http.server.hateos;
 
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
@@ -29,10 +30,12 @@ public interface UnsupportedHateosHttpEntityHandlerHandleMany<I extends Comparab
     default HttpEntity handleMany(final Set<I> ids,
                                   final HttpEntity entity,
                                   final Map<HttpRequestAttribute<?>, Object> parameters,
+                                  final UrlPath path,
                                   final X context) {
         HateosHttpEntityHandler.checkManyIds(ids);
         HateosHttpEntityHandler.checkHttpEntity(entity);
         HateosHttpEntityHandler.checkParameters(parameters);
+        HateosHttpEntityHandler.checkPath(path);
         HateosHttpEntityHandler.checkContext(context);
 
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosHttpEntityHandlerHandleNone.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosHttpEntityHandlerHandleNone.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.net.http.server.hateos;
 
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
@@ -27,9 +28,11 @@ public interface UnsupportedHateosHttpEntityHandlerHandleNone<I extends Comparab
     @Override
     default HttpEntity handleNone(final HttpEntity entity,
                                   final Map<HttpRequestAttribute<?>, Object> parameters,
+                                  final UrlPath path,
                                   final X context) {
         HateosHttpEntityHandler.checkHttpEntity(entity);
         HateosHttpEntityHandler.checkParameters(parameters);
+        HateosHttpEntityHandler.checkPath(path);
         HateosHttpEntityHandler.checkContext(context);
 
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosHttpEntityHandlerHandleOne.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosHttpEntityHandlerHandleOne.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.net.http.server.hateos;
 
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
@@ -28,10 +29,12 @@ public interface UnsupportedHateosHttpEntityHandlerHandleOne<I extends Comparabl
     default HttpEntity handleOne(final I id,
                                  final HttpEntity entity,
                                  final Map<HttpRequestAttribute<?>, Object> parameters,
+                                 final UrlPath path,
                                  final X context) {
         HateosHttpEntityHandler.checkId(id);
         HateosHttpEntityHandler.checkHttpEntity(entity);
         HateosHttpEntityHandler.checkParameters(parameters);
+        HateosHttpEntityHandler.checkPath(path);
         HateosHttpEntityHandler.checkContext(context);
 
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosHttpEntityHandlerHandleRange.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosHttpEntityHandlerHandleRange.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.collect.Range;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
@@ -29,10 +30,12 @@ public interface UnsupportedHateosHttpEntityHandlerHandleRange<I extends Compara
     default HttpEntity handleRange(final Range<I> ids,
                                    final HttpEntity entity,
                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                   final UrlPath path,
                                    final X context) {
         HateosHttpEntityHandler.checkIdRange(ids);
         HateosHttpEntityHandler.checkHttpEntity(entity);
         HateosHttpEntityHandler.checkParameters(parameters);
+        HateosHttpEntityHandler.checkPathEmpty(path);
         HateosHttpEntityHandler.checkContext(context);
 
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosResourceHandlerHandleAll.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosResourceHandlerHandleAll.java
@@ -17,22 +17,25 @@
 
 package walkingkooka.net.http.server.hateos;
 
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
 import java.util.Map;
 import java.util.Optional;
 
 /**
- * A {@link HateosResourceHandler#handleAll(Optional, Map, HateosResourceHandlerContext)} that throws {@link UnsupportedOperationException}.
+ * A {@link HateosResourceHandler#handleAll(Optional, Map, UrlPath, HateosResourceHandlerContext)} that throws {@link UnsupportedOperationException}.
  */
 public interface UnsupportedHateosResourceHandlerHandleAll<I extends Comparable<I>, V, C, X extends HateosResourceHandlerContext> extends HateosResourceHandler<I, V, C, X> {
 
     @Override
     default Optional<C> handleAll(final Optional<C> resource,
                                   final Map<HttpRequestAttribute<?>, Object> parameters,
+                                  final UrlPath path,
                                   final X context) {
         HateosResourceHandler.checkResource(resource);
         HateosResourceHandler.checkParameters(parameters);
+        HateosResourceHandler.checkPath(path);
         HateosResourceHandler.checkContext(context);
 
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosResourceHandlerHandleMany.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosResourceHandlerHandleMany.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.net.http.server.hateos;
 
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
 import java.util.Map;
@@ -24,7 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * A {@link HateosResourceHandler#handleMany(Set, Optional, Map, HateosResourceHandlerContext)} that throws {@link UnsupportedOperationException}.
+ * A {@link HateosResourceHandler#handleMany(Set, Optional, Map, UrlPath, HateosResourceHandlerContext)} that throws {@link UnsupportedOperationException}.
  */
 public interface UnsupportedHateosResourceHandlerHandleMany<I extends Comparable<I>, V, C, X extends HateosResourceHandlerContext> extends HateosResourceHandler<I, V, C, X> {
 
@@ -32,10 +33,12 @@ public interface UnsupportedHateosResourceHandlerHandleMany<I extends Comparable
     default Optional<C> handleMany(final Set<I> ids,
                                    final Optional<C> resource,
                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                   final UrlPath path,
                                    final X context) {
         HateosResourceHandler.checkManyIds(ids);
         HateosResourceHandler.checkResource(resource);
         HateosResourceHandler.checkParameters(parameters);
+        HateosResourceHandler.checkPathEmpty(path);
         HateosResourceHandler.checkContext(context);
 
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosResourceHandlerHandleNone.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosResourceHandlerHandleNone.java
@@ -17,22 +17,25 @@
 
 package walkingkooka.net.http.server.hateos;
 
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
 import java.util.Map;
 import java.util.Optional;
 
 /**
- * A {@link HateosResourceHandler#handleNone(Optional, Map, HateosResourceHandlerContext)} that throws {@link UnsupportedOperationException}.
+ * A {@link HateosResourceHandler#handleNone(Optional, Map, UrlPath, HateosResourceHandlerContext)} that throws {@link UnsupportedOperationException}.
  */
 public interface UnsupportedHateosResourceHandlerHandleNone<I extends Comparable<I>, V, C, X extends HateosResourceHandlerContext> extends HateosResourceHandler<I, V, C, X> {
 
     @Override
     default Optional<V> handleNone(final Optional<V> resource,
                                    final Map<HttpRequestAttribute<?>, Object> parameters,
+                                   final UrlPath path,
                                    final X context) {
         HateosResourceHandler.checkResource(resource);
         HateosResourceHandler.checkParameters(parameters);
+        HateosResourceHandler.checkPath(path);
         HateosResourceHandler.checkContext(context);
 
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosResourceHandlerHandleOne.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosResourceHandlerHandleOne.java
@@ -17,13 +17,14 @@
 
 package walkingkooka.net.http.server.hateos;
 
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
 import java.util.Map;
 import java.util.Optional;
 
 /**
- * A {@link HateosResourceHandler#handleOne(Comparable, Optional, Map, HateosResourceHandlerContext)} that throws {@link UnsupportedOperationException}.
+ * A {@link HateosResourceHandler#handleOne(Comparable, Optional, Map, UrlPath, HateosResourceHandlerContext)} that throws {@link UnsupportedOperationException}.
  */
 public interface UnsupportedHateosResourceHandlerHandleOne<I extends Comparable<I>, V, C, X extends HateosResourceHandlerContext> extends HateosResourceHandler<I, V, C, X> {
 
@@ -31,10 +32,12 @@ public interface UnsupportedHateosResourceHandlerHandleOne<I extends Comparable<
     default Optional<V> handleOne(final I id,
                                   final Optional<V> resource,
                                   final Map<HttpRequestAttribute<?>, Object> parameters,
+                                  final UrlPath path,
                                   final X context) {
         HateosResourceHandler.checkId(id);
         HateosResourceHandler.checkResource(resource);
         HateosResourceHandler.checkParameters(parameters);
+        HateosResourceHandler.checkPathEmpty(path);
         HateosResourceHandler.checkContext(context);
 
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosResourceHandlerHandleRange.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/UnsupportedHateosResourceHandlerHandleRange.java
@@ -18,13 +18,14 @@
 package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.collect.Range;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 
 import java.util.Map;
 import java.util.Optional;
 
 /**
- * A {@link HateosResourceHandler#handleRange(Range, Optional, Map, HateosResourceHandlerContext)} that throws {@link UnsupportedOperationException}.
+ * A {@link HateosResourceHandler#handleRange(Range, Optional, Map, UrlPath, HateosResourceHandlerContext)} that throws {@link UnsupportedOperationException}.
  */
 public interface UnsupportedHateosResourceHandlerHandleRange<I extends Comparable<I>, V, C, X extends HateosResourceHandlerContext> extends HateosResourceHandler<I, V, C, X> {
 
@@ -32,10 +33,12 @@ public interface UnsupportedHateosResourceHandlerHandleRange<I extends Comparabl
     default Optional<C> handleRange(final Range<I> range,
                                     final Optional<C> resource,
                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                    final UrlPath path,
                                     final X context) {
         HateosResourceHandler.checkIdRange(range);
         HateosResourceHandler.checkResource(resource);
         HateosResourceHandler.checkParameters(parameters);
+        HateosResourceHandler.checkPathEmpty(path);
         HateosResourceHandler.checkContext(context);
 
         throw new UnsupportedOperationException();

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceHandlerTestingTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceHandlerTestingTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.Range;
 import walkingkooka.collect.set.Sets;
+import walkingkooka.net.UrlPath;
 import walkingkooka.net.http.server.HttpRequestAttribute;
 import walkingkooka.net.http.server.hateos.HateosResourceHandlerTestingTest.TestHateosResourceHandlerContext;
 import walkingkooka.reflect.JavaVisibility;
@@ -48,12 +49,13 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
 
     }
 
-    // handleAll....................................................................................................
+    // handleAll........................................................................................................
 
     @Test
     public void testHandleAllAndCheck() {
         final Optional<TestHateosResource2> in = this.collectionResource();
         final Map<HttpRequestAttribute<?>, Object> parameters = this.parameters();
+        final UrlPath path = this.path();
 
         final TestHateosResource2 out = TestHateosResource2.with(BigInteger.ONE);
 
@@ -63,9 +65,11 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
                     @Override
                     public Optional<TestHateosResource2> handleAll(final Optional<TestHateosResource2> r,
                                                                    final Map<HttpRequestAttribute<?>, Object> p,
+                                                                   final UrlPath pp,
                                                                    final TestHateosResourceHandlerContext x) {
                         assertSame(in, r);
                         assertSame(parameters, p);
+                        assertSame(path, pp);
                         assertSame(CONTEXT, x);
 
                         return Optional.of(out);
@@ -73,6 +77,7 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
                 },
                 in,
                 parameters,
+                path,
                 CONTEXT,
                 Optional.of(out)
         );
@@ -85,6 +90,7 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
         final Set<BigInteger> ids = this.manyIds();
         final Optional<TestHateosResource2> in = this.collectionResource();
         final Map<HttpRequestAttribute<?>, Object> parameters = this.parameters();
+        final UrlPath path = this.path();
 
         final TestHateosResource2 out = TestHateosResource2.with(BigInteger.ONE);
 
@@ -94,10 +100,12 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
                     public Optional<TestHateosResource2> handleMany(final Set<BigInteger> i,
                                                                     final Optional<TestHateosResource2> r,
                                                                     final Map<HttpRequestAttribute<?>, Object> p,
+                                                                    final UrlPath pp,
                                                                     final TestHateosResourceHandlerContext x) {
                         assertSame(ids, i);
                         assertSame(in, r);
                         assertSame(parameters, p);
+                        assertSame(path, pp);
                         assertSame(CONTEXT, x);
 
                         return Optional.of(out);
@@ -106,6 +114,7 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
                 ids,
                 in,
                 parameters,
+                path,
                 CONTEXT,
                 Optional.of(out)
         );
@@ -117,6 +126,7 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
     public void testHandleNoneAndCheck() {
         final Optional<TestHateosResource> in = this.resource();
         final Map<HttpRequestAttribute<?>, Object> parameters = this.parameters();
+        final UrlPath path = this.path();
 
         final TestHateosResource out = TestHateosResource.with(BigInteger.ONE);
 
@@ -126,9 +136,11 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
                     @Override
                     public Optional<TestHateosResource> handleNone(final Optional<TestHateosResource> r,
                                                                    final Map<HttpRequestAttribute<?>, Object> p,
+                                                                   final UrlPath pp,
                                                                    final TestHateosResourceHandlerContext x) {
                         assertSame(in, r);
                         assertSame(parameters, p);
+                        assertSame(path, pp);
                         assertSame(CONTEXT, x);
 
                         return Optional.of(out);
@@ -136,6 +148,7 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
                 },
                 in,
                 parameters,
+                path,
                 CONTEXT,
                 Optional.of(out)
         );
@@ -148,6 +161,7 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
         final BigInteger id = this.id();
         final Optional<TestHateosResource> in = this.resource();
         final Map<HttpRequestAttribute<?>, Object> parameters = this.parameters();
+        final UrlPath path = this.path();
 
         final TestHateosResource out = TestHateosResource.with(BigInteger.ONE);
 
@@ -157,10 +171,12 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
                     public Optional<TestHateosResource> handleOne(final BigInteger i,
                                                                   final Optional<TestHateosResource> r,
                                                                   final Map<HttpRequestAttribute<?>, Object> p,
+                                                                  final UrlPath pp,
                                                                   final TestHateosResourceHandlerContext x) {
                         assertSame(id, i);
                         assertSame(in, r);
                         assertSame(parameters, p);
+                        assertSame(path, pp);
                         assertSame(CONTEXT, x);
 
                         return Optional.of(out);
@@ -169,6 +185,7 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
                 id,
                 in,
                 parameters,
+                path,
                 CONTEXT,
                 Optional.of(out)
         );
@@ -181,6 +198,7 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
         final Range<BigInteger> range = this.range();
         final Optional<TestHateosResource2> in = this.collectionResource();
         final Map<HttpRequestAttribute<?>, Object> parameters = this.parameters();
+        final UrlPath path = this.path();
 
         final TestHateosResource2 out = TestHateosResource2.with(BigInteger.ONE);
 
@@ -190,10 +208,12 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
                     public Optional<TestHateosResource2> handleRange(final Range<BigInteger> rr,
                                                                      final Optional<TestHateosResource2> r,
                                                                      final Map<HttpRequestAttribute<?>, Object> p,
+                                                                     final UrlPath pp,
                                                                      final TestHateosResourceHandlerContext x) {
                         assertSame(range, rr);
                         assertSame(in, r);
                         assertSame(parameters, p);
+                        assertSame(path, pp);
                         assertSame(CONTEXT, x);
 
                         return Optional.of(out);
@@ -202,6 +222,7 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
                 range,
                 in,
                 parameters,
+                path,
                 CONTEXT,
                 Optional.of(out)
         );
@@ -246,6 +267,11 @@ public final class HateosResourceHandlerTestingTest implements HateosResourceHan
     @Override
     public Map<HttpRequestAttribute<?>, Object> parameters() {
         return HateosResourceHandler.NO_PARAMETERS;
+    }
+
+    @Override
+    public UrlPath path() {
+        return UrlPath.parse("/path123");
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingRouterTest.java
@@ -418,7 +418,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                             public Optional<TestResource> handleOne(final BigInteger id,
                                                                     final Optional<TestResource> resource,
                                                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                                    final UrlPath path,
                                                                     final TestHateosResourceHandlerContext context) {
+                                HateosResourceHandler.checkPathEmpty(path);
+
                                 return Optional.empty();
                             }
                         }),
@@ -450,7 +453,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                             public Optional<TestResource> handleOne(final BigInteger id,
                                                                     final Optional<TestResource> resource,
                                                                     final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                                    final UrlPath path,
                                                                     final TestHateosResourceHandlerContext context) {
+                                HateosResourceHandler.checkPathEmpty(path);
+
                                 return Optional.empty();
                             }
                         }),
@@ -518,7 +524,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleOne(final BigInteger id,
                                                             final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         throw new UnsupportedOperationException(customMessage);
                     }
                 },
@@ -539,7 +548,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     @Override
                     public Optional<TestResource> handleAll(final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         throw new UnsupportedOperationException(customMessage);
                     }
                 },
@@ -560,7 +572,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleRange(final Range<BigInteger> ids,
                                                               final Optional<TestResource> resource,
                                                               final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                              final UrlPath path,
                                                               final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         throw new UnsupportedOperationException(customMessage);
                     }
                 },
@@ -581,7 +596,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleOne(final BigInteger id,
                                                             final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         throw new UnsupportedOperationException(message);
                     }
                 },
@@ -604,7 +622,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleOne(final BigInteger id,
                                                             final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         throw new RuntimeException(INTERNAL_SERVER_ERROR_MESSAGE);
                     }
                 },
@@ -622,7 +643,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     @Override
                     public Optional<TestResource> handleAll(final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         throw new RuntimeException(INTERNAL_SERVER_ERROR_MESSAGE);
                     }
                 },
@@ -640,8 +664,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     @Override
                     public Optional<TestResource> handleRange(final Range<BigInteger> ids,
                                                               final Optional<TestResource> resource,
-                                                              final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                              final Map<HttpRequestAttribute<?>, Object> parameters, final UrlPath path,
                                                               final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         throw new RuntimeException(INTERNAL_SERVER_ERROR_MESSAGE);
                     }
                 },
@@ -662,7 +688,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleOne(final BigInteger id,
                                                             final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         throw new RuntimeException(message);
                     }
                 },
@@ -725,9 +754,11 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleOne(final BigInteger id,
                                                             final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
                         checkId(id);
                         checkResource(resource, Optional.empty());
+                        HateosResourceHandler.checkPathEmpty(path);
 
                         return Optional.empty();
                     }
@@ -750,9 +781,11 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleOne(final BigInteger id,
                                                             final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
                         checkId(id);
                         checkResource(resource, Optional.empty());
+                        HateosResourceHandler.checkPathEmpty(path);
 
                         return Optional.empty();
                     }
@@ -775,9 +808,11 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleOne(final BigInteger id,
                                                             final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
                         checkId(id);
                         checkResource(resource, Optional.of(RESOURCE_IN));
+                        HateosResourceHandler.checkPathEmpty(path);
 
                         return Optional.empty();
                     }
@@ -800,9 +835,11 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleOne(final BigInteger id,
                                                             final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
                         checkId(id);
                         checkResource(resource, Optional.of(RESOURCE_IN));
+                        HateosResourceHandler.checkPathEmpty(path);
 
                         return Optional.empty();
                     }
@@ -837,8 +874,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     @Override
                     public Optional<TestResource> handleAll(final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
                         checkResource(resource, Optional.empty());
+                        HateosResourceHandler.checkPathEmpty(path);
 
                         return Optional.empty();
                     }
@@ -860,8 +899,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     @Override
                     public Optional<TestResource> handleAll(final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
                         checkResource(resource, Optional.empty());
+                        HateosResourceHandler.checkPathEmpty(path);
 
                         return Optional.empty();
                     }
@@ -883,8 +924,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     @Override
                     public Optional<TestResource> handleAll(final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
                         checkResource(resource, Optional.of(COLLECTION_RESOURCE_IN));
+                        HateosResourceHandler.checkPathEmpty(path);
 
                         return Optional.empty();
                     }
@@ -910,9 +953,11 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleRange(final Range<BigInteger> id,
                                                               final Optional<TestResource> resource,
                                                               final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                              final UrlPath path,
                                                               final TestHateosResourceHandlerContext context) {
                         checkRange(id);
                         checkResource(resource, Optional.empty());
+                        HateosResourceHandler.checkPathEmpty(path);
 
                         return Optional.empty();
                     }
@@ -935,9 +980,11 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleRange(final Range<BigInteger> id,
                                                               final Optional<TestResource> resource,
                                                               final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                              final UrlPath path,
                                                               final TestHateosResourceHandlerContext context) {
                         checkRange(id);
                         checkResource(resource, Optional.empty());
+                        HateosResourceHandler.checkPathEmpty(path);
 
                         return Optional.empty();
                     }
@@ -960,9 +1007,11 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleRange(final Range<BigInteger> id,
                                                               final Optional<TestResource> resource,
                                                               final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                              final UrlPath path,
                                                               final TestHateosResourceHandlerContext context) {
                         checkRange(id);
                         checkResource(resource, Optional.of(COLLECTION_RESOURCE_IN));
+                        HateosResourceHandler.checkPathEmpty(path);
 
                         return Optional.empty();
                     }
@@ -999,7 +1048,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     @Override
                     public Optional<TestResource> handleNone(final Optional<TestResource> resource,
                                                              final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                             final UrlPath path,
                                                              final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         return Optional.empty();
                     }
                 },
@@ -1020,7 +1072,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     @Override
                     public Optional<TestResource> handleNone(final Optional<TestResource> resource,
                                                              final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                             final UrlPath path,
                                                              final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         return Optional.of(RESOURCE_OUT);
                     }
                 },
@@ -1042,7 +1097,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleOne(final BigInteger id,
                                                             final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         return Optional.empty();
                     }
                 },
@@ -1064,7 +1122,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleOne(final BigInteger id,
                                                             final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         return Optional.of(RESOURCE_OUT);
                     }
                 },
@@ -1086,7 +1147,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleRange(final Range<BigInteger> id,
                                                               final Optional<TestResource> resource,
                                                               final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                              final UrlPath path,
                                                               final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         return Optional.empty();
                     }
                 },
@@ -1108,7 +1172,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleRange(final Range<BigInteger> id,
                                                               final Optional<TestResource> resource,
                                                               final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                              final UrlPath path,
                                                               final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         return Optional.of(COLLECTION_RESOURCE_OUT);
                     }
                 },
@@ -1147,7 +1214,10 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public Optional<TestResource> handleOne(final BigInteger id,
                                                             final Optional<TestResource> resource,
                                                             final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                            final UrlPath path,
                                                             final TestHateosResourceHandlerContext context) {
+                        HateosResourceHandler.checkPathEmpty(path);
+
                         return Optional.of(
                                 TestResource.with(
                                         TestHateosResource.with(
@@ -1242,6 +1312,402 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
 
     @Test
     public void testSetHateosHttpEntityHandlerAndRoute() {
+        this.setHateosHttpEntityHandlerAndRouteWithPathAndCheck(
+                "/api/resource-with-body/0x123/contents",
+                ""
+        );
+//        final MediaType mediaType = MediaType.TEXT_PLAIN;
+//
+//        final HateosResourceMapping<BigInteger, TestResource, TestResource, TestHateosResource, TestHateosResourceHandlerContext> mapping = HateosResourceMapping.with(
+//                HateosResourceName.with("resource-with-body"),
+//                (s, x) -> {
+//                    return HateosResourceSelection.one(
+//                            BigInteger.valueOf(
+//                                    Integer.parseInt(
+//                                            s.substring(2),
+//                                            16
+//                                    )
+//                            )
+//                    ); // assumes hex digit in url
+//                },
+//                TestResource.class,
+//                TestResource.class,
+//                TestHateosResource.class,
+//                TestHateosResourceHandlerContext.class
+//        ).setHateosHttpEntityHandler(
+//                LinkRelation.CONTENTS,
+//                HttpMethod.POST,
+//                new FakeHateosHttpEntityHandler<BigInteger, TestHateosResourceHandlerContext>() {
+//                    @Override
+//                    public HttpEntity handleOne(final BigInteger id,
+//                                                final HttpEntity entity,
+//                                                final Map<HttpRequestAttribute<?>, Object> parameters,
+//                                                final UrlPath path,
+//                                                final TestHateosResourceHandlerContext context) {
+//                        checkEquals(
+//                                mediaType,
+//                                HttpHeaderName.CONTENT_TYPE.headerOrFail(entity)
+//                        );
+//                        HateosResourceHandler.checkPathEmpty(path);
+//
+//                        return HttpEntity.EMPTY.setBodyText(
+//                                id +
+//                                        "\n" +
+//                                        entity.bodyText()
+//                        );
+//                    }
+//                }
+//        );
+//
+//        final Router<HttpRequestAttribute<?>, HttpHandler> router = HateosResourceMapping.router(
+//                UrlPath.parse("/api"),
+//                Sets.of(mapping),
+//                INDENTATION,
+//                LINE_ENDING,
+//                CONTEXT
+//        );
+//
+//        final HttpRequest request = new FakeHttpRequest() {
+//
+//            @Override
+//            public HttpTransport transport() {
+//                return HttpTransport.UNSECURED;
+//            }
+//
+//            @Override
+//            public HttpProtocolVersion protocolVersion() {
+//                return HttpProtocolVersion.VERSION_1_0;
+//            }
+//
+//            @Override
+//            public HttpMethod method() {
+//                return HttpMethod.POST;
+//            }
+//
+//            @Override
+//            public RelativeUrl url() {
+//                return Url.parseRelative("/api/resource-with-body/0x123/contents");
+//            }
+//
+//            @Override
+//            public Map<HttpHeaderName<?>, List<?>> headers() {
+//                return Maps.of(
+//                        HttpHeaderName.CONTENT_TYPE, Lists.of(mediaType),
+//                        HttpHeaderName.ACCEPT, Lists.of(mediaType.accept()),
+//                        HttpHeaderName.ACCEPT_CHARSET, Lists.of(AcceptCharset.parse("utf-8"))
+//                );
+//            }
+//
+//            @Override
+//            public byte[] body() {
+//                return this.bodyText()
+//                        .getBytes(StandardCharsets.UTF_8);
+//            }
+//
+//            @Override
+//            public String bodyText() {
+//                return "RequestBodyText123";
+//            }
+//
+//            @Override
+//            public Map<HttpRequestParameterName, List<String>> parameters() {
+//                return Maps.empty();
+//            }
+//
+//            @Override
+//            public List<String> parameterValues(final HttpRequestParameterName parameterName) {
+//                throw new UnsupportedOperationException();
+//            }
+//
+//            @Override
+//            public String toString() {
+//                return this.method() + " " + this.url() + " " + parameters();
+//            }
+//        };
+//        final HttpHandler httpHandler = router.route(
+//                request.routerParameters()
+//        ).orElseThrow(
+//                () -> new Error("Unable to route")
+//        );
+//
+//        final HttpResponse response = HttpResponses.recording();
+//        httpHandler.handle(request, response);
+//        this.checkEquals(
+//                "291\n" + // 0x123
+//                        "RequestBodyText123",
+//                response.entity()
+//                        .bodyText()
+//        );
+    }
+
+    @Test
+    public void testSetHateosHttpEntityHandlerAndRouteWithPath() {
+        this.setHateosHttpEntityHandlerAndRouteWithPathAndCheck(
+                "/api/resource-with-body/0x123/contents/",
+                "/"
+        );
+//        final MediaType mediaType = MediaType.TEXT_PLAIN;
+//
+//        final HateosResourceMapping<BigInteger, TestResource, TestResource, TestHateosResource, TestHateosResourceHandlerContext> mapping = HateosResourceMapping.with(
+//                HateosResourceName.with("resource-with-body"),
+//                (s, x) -> {
+//                    return HateosResourceSelection.one(
+//                            BigInteger.valueOf(
+//                                    Integer.parseInt(
+//                                            s.substring(2),
+//                                            16
+//                                    )
+//                            )
+//                    ); // assumes hex digit in url
+//                },
+//                TestResource.class,
+//                TestResource.class,
+//                TestHateosResource.class,
+//                TestHateosResourceHandlerContext.class
+//        ).setHateosHttpEntityHandler(
+//                LinkRelation.CONTENTS,
+//                HttpMethod.POST,
+//                new FakeHateosHttpEntityHandler<BigInteger, TestHateosResourceHandlerContext>() {
+//                    @Override
+//                    public HttpEntity handleOne(final BigInteger id,
+//                                                final HttpEntity entity,
+//                                                final Map<HttpRequestAttribute<?>, Object> parameters,
+//                                                final UrlPath path,
+//                                                final TestHateosResourceHandlerContext context) {
+//                        checkEquals(
+//                                mediaType,
+//                                HttpHeaderName.CONTENT_TYPE.headerOrFail(entity)
+//                        );
+//                        checkEquals(
+//                                UrlPath.parse("/"),
+//                                path
+//                        );
+//
+//                        return HttpEntity.EMPTY.setBodyText(
+//                                id +
+//                                        "\n" +
+//                                        entity.bodyText()
+//                        );
+//                    }
+//                }
+//        );
+//
+//        final Router<HttpRequestAttribute<?>, HttpHandler> router = HateosResourceMapping.router(
+//                UrlPath.parse("/api"),
+//                Sets.of(mapping),
+//                INDENTATION,
+//                LINE_ENDING,
+//                CONTEXT
+//        );
+//
+//        final HttpRequest request = new FakeHttpRequest() {
+//
+//            @Override
+//            public HttpTransport transport() {
+//                return HttpTransport.UNSECURED;
+//            }
+//
+//            @Override
+//            public HttpProtocolVersion protocolVersion() {
+//                return HttpProtocolVersion.VERSION_1_0;
+//            }
+//
+//            @Override
+//            public HttpMethod method() {
+//                return HttpMethod.POST;
+//            }
+//
+//            @Override
+//            public RelativeUrl url() {
+//                return Url.parseRelative("/api/resource-with-body/0x123/contents/");
+//            }
+//
+//            @Override
+//            public Map<HttpHeaderName<?>, List<?>> headers() {
+//                return Maps.of(
+//                        HttpHeaderName.CONTENT_TYPE, Lists.of(mediaType),
+//                        HttpHeaderName.ACCEPT, Lists.of(mediaType.accept()),
+//                        HttpHeaderName.ACCEPT_CHARSET, Lists.of(AcceptCharset.parse("utf-8"))
+//                );
+//            }
+//
+//            @Override
+//            public byte[] body() {
+//                return this.bodyText()
+//                        .getBytes(StandardCharsets.UTF_8);
+//            }
+//
+//            @Override
+//            public String bodyText() {
+//                return "RequestBodyText123";
+//            }
+//
+//            @Override
+//            public Map<HttpRequestParameterName, List<String>> parameters() {
+//                return Maps.empty();
+//            }
+//
+//            @Override
+//            public List<String> parameterValues(final HttpRequestParameterName parameterName) {
+//                throw new UnsupportedOperationException();
+//            }
+//
+//            @Override
+//            public String toString() {
+//                return this.method() + " " + this.url() + " " + parameters();
+//            }
+//        };
+//        final HttpHandler httpHandler = router.route(
+//                request.routerParameters()
+//        ).orElseThrow(
+//                () -> new Error("Unable to route")
+//        );
+//
+//        final HttpResponse response = HttpResponses.recording();
+//        httpHandler.handle(request, response);
+//        this.checkEquals(
+//                "291\n" + // 0x123
+//                        "RequestBodyText123",
+//                response.entity()
+//                        .bodyText()
+//        );
+    }
+
+    @Test
+    public void testSetHateosHttpEntityHandlerAndRouteWithPath2() {
+        this.setHateosHttpEntityHandlerAndRouteWithPathAndCheck(
+                "/api/resource-with-body/0x123/contents/path1/path2",
+                "/path1/path2"
+        );
+//        final MediaType mediaType = MediaType.TEXT_PLAIN;
+//
+//        final HateosResourceMapping<BigInteger, TestResource, TestResource, TestHateosResource, TestHateosResourceHandlerContext> mapping = HateosResourceMapping.with(
+//                HateosResourceName.with("resource-with-body"),
+//                (s, x) -> {
+//                    return HateosResourceSelection.one(
+//                            BigInteger.valueOf(
+//                                    Integer.parseInt(
+//                                            s.substring(2),
+//                                            16
+//                                    )
+//                            )
+//                    ); // assumes hex digit in url
+//                },
+//                TestResource.class,
+//                TestResource.class,
+//                TestHateosResource.class,
+//                TestHateosResourceHandlerContext.class
+//        ).setHateosHttpEntityHandler(
+//                LinkRelation.CONTENTS,
+//                HttpMethod.POST,
+//                new FakeHateosHttpEntityHandler<BigInteger, TestHateosResourceHandlerContext>() {
+//                    @Override
+//                    public HttpEntity handleOne(final BigInteger id,
+//                                                final HttpEntity entity,
+//                                                final Map<HttpRequestAttribute<?>, Object> parameters,
+//                                                final UrlPath path,
+//                                                final TestHateosResourceHandlerContext context) {
+//                        checkEquals(
+//                                mediaType,
+//                                HttpHeaderName.CONTENT_TYPE.headerOrFail(entity)
+//                        );
+//                        checkEquals(
+//                                UrlPath.parse("/path1/path2"),
+//                                path
+//                        );
+//
+//                        return HttpEntity.EMPTY.setBodyText(
+//                                id +
+//                                        "\n" +
+//                                        entity.bodyText()
+//                        );
+//                    }
+//                }
+//        );
+//
+//        final Router<HttpRequestAttribute<?>, HttpHandler> router = HateosResourceMapping.router(
+//                UrlPath.parse("/api"),
+//                Sets.of(mapping),
+//                INDENTATION,
+//                LINE_ENDING,
+//                CONTEXT
+//        );
+//
+//        final HttpRequest request = new FakeHttpRequest() {
+//
+//            @Override
+//            public HttpTransport transport() {
+//                return HttpTransport.UNSECURED;
+//            }
+//
+//            @Override
+//            public HttpProtocolVersion protocolVersion() {
+//                return HttpProtocolVersion.VERSION_1_0;
+//            }
+//
+//            @Override
+//            public HttpMethod method() {
+//                return HttpMethod.POST;
+//            }
+//
+//            @Override
+//            public RelativeUrl url() {
+//                return Url.parseRelative("/api/resource-with-body/0x123/contents/path1/path2");
+//            }
+//
+//            @Override
+//            public Map<HttpHeaderName<?>, List<?>> headers() {
+//                return Maps.of(
+//                        HttpHeaderName.CONTENT_TYPE, Lists.of(mediaType),
+//                        HttpHeaderName.ACCEPT, Lists.of(mediaType.accept()),
+//                        HttpHeaderName.ACCEPT_CHARSET, Lists.of(AcceptCharset.parse("utf-8"))
+//                );
+//            }
+//
+//            @Override
+//            public byte[] body() {
+//                return this.bodyText()
+//                        .getBytes(StandardCharsets.UTF_8);
+//            }
+//
+//            @Override
+//            public String bodyText() {
+//                return "RequestBodyText123";
+//            }
+//
+//            @Override
+//            public Map<HttpRequestParameterName, List<String>> parameters() {
+//                return Maps.empty();
+//            }
+//
+//            @Override
+//            public List<String> parameterValues(final HttpRequestParameterName parameterName) {
+//                throw new UnsupportedOperationException();
+//            }
+//
+//            @Override
+//            public String toString() {
+//                return this.method() + " " + this.url() + " " + parameters();
+//            }
+//        };
+//        final HttpHandler httpHandler = router.route(
+//                request.routerParameters()
+//        ).orElseThrow(
+//                () -> new Error("Unable to route")
+//        );
+//
+//        final HttpResponse response = HttpResponses.recording();
+//        httpHandler.handle(request, response);
+//        this.checkEquals(
+//                "291\n" + // 0x123
+//                        "RequestBodyText123",
+//                response.entity()
+//                        .bodyText()
+//        );
+    }
+
+    private void setHateosHttpEntityHandlerAndRouteWithPathAndCheck(final String requestUrl,
+                                                                    final String handlerPath) {
         final MediaType mediaType = MediaType.TEXT_PLAIN;
 
         final HateosResourceMapping<BigInteger, TestResource, TestResource, TestHateosResource, TestHateosResourceHandlerContext> mapping = HateosResourceMapping.with(
@@ -1268,11 +1734,17 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
                     public HttpEntity handleOne(final BigInteger id,
                                                 final HttpEntity entity,
                                                 final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                final UrlPath path,
                                                 final TestHateosResourceHandlerContext context) {
                         checkEquals(
                                 mediaType,
                                 HttpHeaderName.CONTENT_TYPE.headerOrFail(entity)
                         );
+                        checkEquals(
+                                UrlPath.parse(handlerPath),
+                                path
+                        );
+
                         return HttpEntity.EMPTY.setBodyText(
                                 id +
                                         "\n" +
@@ -1283,7 +1755,7 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
         );
 
         final Router<HttpRequestAttribute<?>, HttpHandler> router = HateosResourceMapping.router(
-                UrlPath.parse("api"),
+                UrlPath.parse("/api"),
                 Sets.of(mapping),
                 INDENTATION,
                 LINE_ENDING,
@@ -1309,7 +1781,7 @@ public final class HateosResourceMappingRouterTest extends HateosResourceMapping
 
             @Override
             public RelativeUrl url() {
-                return Url.parseRelative("/api/resource-with-body/0x123/contents");
+                return Url.parseRelative(requestUrl);
             }
 
             @Override

--- a/src/test/java/walkingkooka/net/http/server/hateos/sample/Sample.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/sample/Sample.java
@@ -127,6 +127,7 @@ public class Sample {
                     public Optional<TestResource3> handleOne(final BigInteger id,
                                                              final Optional<TestResource3> resource,
                                                              final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                             final UrlPath path,
                                                              final TestHateosResourceHandlerContext context) {
                         return Optional.of(
                                 TestResource3.with(


### PR DESCRIPTION
- This will enable or support the following:
- A file path after identifying a hateos resource and its id.
- More than one hateos resource within a single url eg: /api/spreadsheet/1/cell/A1/form/Form1