### PR TITLE
HateosResourceMappings replaced wildcards with actual type-parameters

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHttpEntityHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHttpEntityHandler.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Handles a HATEOS request for a one or more {@link HateosResource} as a single {@link walkingkooka.net.http.HttpEntity}.
+ * Handles a HATEOS request for a one or more {@link HateosResource} as a single {@link HttpEntity}.
  */
 public interface HateosHttpEntityHandler<I extends Comparable<I>, X extends HateosResourceHandlerContext> {
 

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappings.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappings.java
@@ -263,11 +263,11 @@ public final class HateosResourceMappings<I extends Comparable<I>, V, C, H exten
     /**
      * Creates a {@link Router} from the provided {@link HateosResourceMappings mappings}.
      */
-    public static Router<HttpRequestAttribute<?>, HttpHandler> router(final UrlPath base,
-                                                                      final Set<HateosResourceMappings<?, ?, ?, ?, ?>> mappings,
-                                                                      final Indentation indentation,
-                                                                      final LineEnding lineEnding,
-                                                                      final HateosResourceHandlerContext context) {
+    public static <X extends HateosResourceHandlerContext> Router<HttpRequestAttribute<?>, HttpHandler> router(final UrlPath base,
+                                                                                                               final Set<HateosResourceMappings<?, ?, ?, ?, X>> mappings,
+                                                                                                               final Indentation indentation,
+                                                                                                               final LineEnding lineEnding,
+                                                                                                               final X context) {
         return HateosResourceMappingsRouter.with(
             base,
             mappings,

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor.java
@@ -33,18 +33,18 @@ import java.util.Set;
 /**
  * A {@link JsonNodeMarshallContextObjectPostProcessor} that adds links for types, and can be used by {@link JsonNodeMarshallContexts#basic}
  */
-final class HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor implements JsonNodeMarshallContextObjectPostProcessor {
+final class HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor<X extends HateosResourceHandlerContext> implements JsonNodeMarshallContextObjectPostProcessor {
 
-    static HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor with(final AbsoluteUrl base,
-                                                                                 final Set<HateosResourceMappings<?, ?, ?, ?, ?>> mappings,
-                                                                                 final HateosResourceHandlerContext context) {
+    static <X extends HateosResourceHandlerContext> HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor<X> with(final AbsoluteUrl base,
+                                                                                                                             final Set<HateosResourceMappings<?, ?, ?, ?, X>> mappings,
+                                                                                                                             final HateosResourceHandlerContext context) {
         final Map<String, HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessorMapping> typeToMappings = Maps.ordered();
 
-        for (final HateosResourceMappings<?, ?, ?, ?, ?> mapping : mappings) {
+        for (final HateosResourceMappings<?, ?, ?, ?, X> mapping : mappings) {
             final HateosResourceName resourceName = mapping.resourceName;
             final Map<LinkRelation<?>, Collection<HttpMethod>> linkRelationToMethods = Maps.ordered();
 
-            for (final HateosResourceMappingsMapping<?, ?, ?, ?, ?> m : mapping.pathNameToMappings.values()) {
+            for (final HateosResourceMappingsMapping<?, ?, ?, ?, X> m : mapping.pathNameToMappings.values()) {
                 final LinkRelation<?> linkRelation = m.linkRelation;
                 if (null != linkRelation) {
                     linkRelationToMethods.put(
@@ -63,7 +63,7 @@ final class HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor imp
             );
         }
 
-        return new HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor(
+        return new HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor<>(
             base,
             typeToMappings,
             context

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsMapping.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsMapping.java
@@ -52,7 +52,7 @@ final class HateosResourceMappingsMapping<I extends Comparable<I>, V, C, H exten
     }
 
     private HateosResourceMappingsMapping(final LinkRelation<?> linkRelation,
-                                          final Map<HttpMethod, HateosResourceMappingsMappingHandler<?>> methodToHandlers,
+                                          final Map<HttpMethod, HateosResourceMappingsMappingHandler<I, V, C, H, X>> methodToHandlers,
                                           final HttpHandler httpHandler) {
         super();
         this.linkRelation = linkRelation;
@@ -69,9 +69,9 @@ final class HateosResourceMappingsMapping<I extends Comparable<I>, V, C, H exten
 
         this.httpHandlerCheck();
 
-        final Map<HttpMethod, HateosResourceMappingsMappingHandler<?>> methodToHandlers = Maps.sorted();
+        final Map<HttpMethod, HateosResourceMappingsMappingHandler<I, V, C, H, X>> methodToHandlers = Maps.sorted();
 
-        Map<HttpMethod, HateosResourceMappingsMappingHandler<?>> previous = this.methodToHandlers;
+        Map<HttpMethod, HateosResourceMappingsMappingHandler<I, V, C, H, X>> previous = this.methodToHandlers;
         if (null != previous) {
             methodToHandlers.putAll(previous);
         }
@@ -99,9 +99,9 @@ final class HateosResourceMappingsMapping<I extends Comparable<I>, V, C, H exten
 
         this.httpHandlerCheck();
 
-        final Map<HttpMethod, HateosResourceMappingsMappingHandler<?>> methodToHandlers = Maps.sorted();
+        final Map<HttpMethod, HateosResourceMappingsMappingHandler<I, V, C, H, X>> methodToHandlers = Maps.sorted();
 
-        Map<HttpMethod, HateosResourceMappingsMappingHandler<?>> previous = this.methodToHandlers;
+        Map<HttpMethod, HateosResourceMappingsMappingHandler<I, V, C, H, X>> previous = this.methodToHandlers;
         if (null != previous) {
             methodToHandlers.putAll(previous);
         }
@@ -120,7 +120,7 @@ final class HateosResourceMappingsMapping<I extends Comparable<I>, V, C, H exten
     }
 
     /**
-     * Sets a {@link walkingkooka.net.http.server.HttpHandler}
+     * Sets a {@link HttpHandler}
      */
     HateosResourceMappingsMapping<I, V, C, H, X> setHttpHandler(final HttpHandler handler) {
         Objects.requireNonNull(handler, "handler");
@@ -142,8 +142,8 @@ final class HateosResourceMappingsMapping<I extends Comparable<I>, V, C, H exten
         }
     }
 
-    void handle(final HateosResourceMappingsRouterHttpHandlerRequest request,
-                final HateosResourceMappings<?, ?, ?, ?, ?> mappings,
+    void handle(final HateosResourceMappingsRouterHttpHandlerRequest<X> request,
+                final HateosResourceMappings<I, V, C, H, X> mappings,
                 final HateosResourceSelection<?> selection,
                 final UrlPath path,
                 final HateosResourceHandlerContext context) {
@@ -156,7 +156,7 @@ final class HateosResourceMappingsMapping<I extends Comparable<I>, V, C, H exten
         } else {
 
             final HttpMethod method = request.request.method();
-            final HateosResourceMappingsMappingHandler<?> handler = this.methodToHandlers.get(method);
+            final HateosResourceMappingsMappingHandler<I, V, C, H, X> handler = this.methodToHandlers.get(method);
             if (null != handler) {
                 handler.handle(
                     request,
@@ -175,7 +175,7 @@ final class HateosResourceMappingsMapping<I extends Comparable<I>, V, C, H exten
         }
     }
 
-    private final Map<HttpMethod, HateosResourceMappingsMappingHandler<?>> methodToHandlers;
+    private final Map<HttpMethod, HateosResourceMappingsMappingHandler<I, V, C, H, X>> methodToHandlers;
 
     private final HttpHandler httpHandler;
 
@@ -201,10 +201,10 @@ final class HateosResourceMappingsMapping<I extends Comparable<I>, V, C, H exten
     public boolean equals(final Object other) {
         return this == other ||
             null != other && this.getClass() == other.getClass()
-                && this.equals0((HateosResourceMappingsMapping<?, ?, ?, ?, ?>) other);
+                && this.equals0((HateosResourceMappingsMapping<I, V, C, H, X>) other);
     }
 
-    private boolean equals0(final HateosResourceMappingsMapping<?, ?, ?, ?, ?> other) {
+    private boolean equals0(final HateosResourceMappingsMapping<I, V, C, H, X> other) {
         return Objects.equals(
             this.methodToHandlers,
             other.methodToHandlers
@@ -228,9 +228,9 @@ final class HateosResourceMappingsMapping<I extends Comparable<I>, V, C, H exten
     public void printTree(final IndentingPrinter printer) {
 
         {
-            final Map<HttpMethod, HateosResourceMappingsMappingHandler<?>> methodToHandlers = this.methodToHandlers;
+            final Map<HttpMethod, HateosResourceMappingsMappingHandler<I, V, C, H, X>> methodToHandlers = this.methodToHandlers;
             if (null != methodToHandlers) {
-                for (final Entry<HttpMethod, HateosResourceMappingsMappingHandler<?>> methodAndHandler : this.methodToHandlers.entrySet()) {
+                for (final Entry<HttpMethod, HateosResourceMappingsMappingHandler<I, V, C, H, X>> methodAndHandler : this.methodToHandlers.entrySet()) {
                     printer.println(methodAndHandler.getKey().value());
 
                     printer.indent();

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsMappingHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsMappingHandler.java
@@ -23,12 +23,12 @@ import walkingkooka.net.http.server.HttpHandler;
 /**
  * A simple wrapper to hold either a {@link HateosHttpEntityHandler} or {@link HateosResourceHandler}
  */
-abstract class HateosResourceMappingsMappingHandler<T> {
+abstract class HateosResourceMappingsMappingHandler<I extends Comparable<I>, V, C, H extends HateosResource<I>, X extends HateosResourceHandlerContext> {
 
     /**
      * {@see HateosResourceMappingsMappingHandlerHateosHttpEntityHandler}
      */
-    static HateosResourceMappingsMappingHandlerHateosHttpEntityHandler hateosHttpEntityHandler(final HateosHttpEntityHandler<?, ?> handler) {
+    static <I extends Comparable<I>, V, C, H extends HateosResource<I>, X extends HateosResourceHandlerContext> HateosResourceMappingsMappingHandlerHateosHttpEntityHandler<I, V, C, H, X> hateosHttpEntityHandler(final HateosHttpEntityHandler<I, X> handler) {
         return HateosResourceMappingsMappingHandlerHateosHttpEntityHandler.with(handler);
     }
 
@@ -36,50 +36,55 @@ abstract class HateosResourceMappingsMappingHandler<T> {
     /**
      * {see HateosResourceMappingsMappingHandlerHateosResourceHandler}
      */
-    static HateosResourceMappingsMappingHandlerHateosResourceHandler hateosResourceHandler(final HateosResourceHandler<?, ?, ?, ?> handler) {
+    static <I extends Comparable<I>, V, C, H extends HateosResource<I>, X extends HateosResourceHandlerContext> HateosResourceMappingsMappingHandlerHateosResourceHandler<I, V, C, H, X> hateosResourceHandler(final HateosResourceHandler<I, V, C, X> handler) {
         return HateosResourceMappingsMappingHandlerHateosResourceHandler.with(handler);
     }
 
     /**
      * {@see HateosResourceMappingsMappingHandlerHttpHandler}
      */
-    static HateosResourceMappingsMappingHandlerHttpHandler httpHandler(final HttpHandler handler) {
+    static <I extends Comparable<I>, V, C, H extends HateosResource<I>, X extends HateosResourceHandlerContext> HateosResourceMappingsMappingHandlerHttpHandler<I, V, C, H, X> httpHandler(final HttpHandler handler) {
         return HateosResourceMappingsMappingHandlerHttpHandler.with(handler);
     }
 
-    HateosResourceMappingsMappingHandler(final T handler) {
+    HateosResourceMappingsMappingHandler() {
         super();
-        this.handler = handler;
     }
 
-    abstract void handle(final HateosResourceMappingsRouterHttpHandlerRequest request,
-                         final HateosResourceMappings<?, ?, ?, ?, ?> mappings,
+    abstract void handle(final HateosResourceMappingsRouterHttpHandlerRequest<X> request,
+                         final HateosResourceMappings<I, V, C, H, X> mappings,
                          final HateosResourceSelection<?> selection,
                          final UrlPath path,
                          final HateosResourceHandlerContext context);
-
-    final T handler;
 
     // Object...........................................................................................................
 
     @Override
     public final int hashCode() {
-        return this.handler.hashCode();
+        return this.handler()
+            .hashCode();
     }
 
     @Override
     public final boolean equals(final Object other) {
         return this == other ||
             null != other && this.getClass() == other.getClass()
-                && this.equals0((HateosResourceMappingsMappingHandler<?>) other);
+                && this.equals0((HateosResourceMappingsMappingHandler<?, ?, ?, ?, ?>) other);
     }
 
-    private boolean equals0(final HateosResourceMappingsMappingHandler<?> other) {
-        return this.handler.equals(other.handler);
+    private boolean equals0(final HateosResourceMappingsMappingHandler<?, ?, ?, ?, ?> other) {
+        return this.handler()
+            .equals(other.handler());
     }
 
     @Override
     public final String toString() {
-        return this.handler.toString();
+        return this.handler()
+            .toString();
     }
+
+    /**
+     * Provides the handler (type is not important) which is used in {@link #hashCode()} and {@link #equals(Object)}.
+     */
+    abstract Object handler();
 }

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsMappingHandlerHateosHttpEntityHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsMappingHandlerHateosHttpEntityHandler.java
@@ -21,21 +21,22 @@ import walkingkooka.net.UrlPath;
 
 import java.util.Objects;
 
-final class HateosResourceMappingsMappingHandlerHateosHttpEntityHandler extends HateosResourceMappingsMappingHandler<HateosHttpEntityHandler<?, ?>> {
+final class HateosResourceMappingsMappingHandlerHateosHttpEntityHandler<I extends Comparable<I>, V, C, H extends HateosResource<I>, X extends HateosResourceHandlerContext> extends HateosResourceMappingsMappingHandler<I, V, C, H, X> {
 
-    static HateosResourceMappingsMappingHandlerHateosHttpEntityHandler with(final HateosHttpEntityHandler<?, ?> handler) {
-        return new HateosResourceMappingsMappingHandlerHateosHttpEntityHandler(
+    static <I extends Comparable<I>, V, C, H extends HateosResource<I>, X extends HateosResourceHandlerContext> HateosResourceMappingsMappingHandlerHateosHttpEntityHandler<I, V, C, H, X> with(final HateosHttpEntityHandler<I, X> handler) {
+        return new HateosResourceMappingsMappingHandlerHateosHttpEntityHandler<>(
             Objects.requireNonNull(handler, "handler")
         );
     }
 
-    private HateosResourceMappingsMappingHandlerHateosHttpEntityHandler(final HateosHttpEntityHandler<?, ?> handler) {
-        super(handler);
+    private HateosResourceMappingsMappingHandlerHateosHttpEntityHandler(final HateosHttpEntityHandler<I, X> handler) {
+        super();
+        this.handler = handler;
     }
 
     @Override
-    void handle(final HateosResourceMappingsRouterHttpHandlerRequest request,
-                final HateosResourceMappings<?, ?, ?, ?, ?> mappings,
+    void handle(final HateosResourceMappingsRouterHttpHandlerRequest<X> request,
+                final HateosResourceMappings<I, V, C, H, X> mappings,
                 final HateosResourceSelection<?> selection,
                 final UrlPath path,
                 final HateosResourceHandlerContext context) {
@@ -46,4 +47,11 @@ final class HateosResourceMappingsMappingHandlerHateosHttpEntityHandler extends 
             context
         );
     }
+
+    @Override
+    HateosHttpEntityHandler<I, X> handler() {
+        return this.handler;
+    }
+
+    private final HateosHttpEntityHandler<I, X> handler;
 }

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsMappingHandlerHateosResourceHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsMappingHandlerHateosResourceHandler.java
@@ -21,21 +21,22 @@ import walkingkooka.net.UrlPath;
 
 import java.util.Objects;
 
-final class HateosResourceMappingsMappingHandlerHateosResourceHandler extends HateosResourceMappingsMappingHandler<HateosResourceHandler<?, ?, ?, ?>> {
+final class HateosResourceMappingsMappingHandlerHateosResourceHandler<I extends Comparable<I>, V, C, H extends HateosResource<I>, X extends HateosResourceHandlerContext> extends HateosResourceMappingsMappingHandler<I, V, C, H, X> {
 
-    static HateosResourceMappingsMappingHandlerHateosResourceHandler with(final HateosResourceHandler<?, ?, ?, ?> handler) {
-        return new HateosResourceMappingsMappingHandlerHateosResourceHandler(
+    static <I extends Comparable<I>, V, C, H extends HateosResource<I>, X extends HateosResourceHandlerContext> HateosResourceMappingsMappingHandlerHateosResourceHandler<I, V, C, H, X> with(final HateosResourceHandler<I, V, C, X> handler) {
+        return new HateosResourceMappingsMappingHandlerHateosResourceHandler<>(
             Objects.requireNonNull(handler, "handler")
         );
     }
 
-    private HateosResourceMappingsMappingHandlerHateosResourceHandler(final HateosResourceHandler<?, ?, ?, ?> handler) {
-        super(handler);
+    private HateosResourceMappingsMappingHandlerHateosResourceHandler(final HateosResourceHandler<I, V, C, X> handler) {
+        super();
+        this.handler = handler;
     }
 
     @Override
-    void handle(final HateosResourceMappingsRouterHttpHandlerRequest request,
-                final HateosResourceMappings<?, ?, ?, ?, ?> mappings,
+    void handle(final HateosResourceMappingsRouterHttpHandlerRequest<X> request,
+                final HateosResourceMappings<I, V, C, H, X> mappings,
                 final HateosResourceSelection<?> selection,
                 final UrlPath path,
                 final HateosResourceHandlerContext context) {
@@ -47,4 +48,11 @@ final class HateosResourceMappingsMappingHandlerHateosResourceHandler extends Ha
             context
         );
     }
+
+    @Override
+    HateosResourceHandler<I, V, C, X> handler() {
+        return this.handler;
+    }
+
+    private final HateosResourceHandler<I, V, C, X> handler;
 }

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsMappingHandlerHttpHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsMappingHandlerHttpHandler.java
@@ -22,21 +22,22 @@ import walkingkooka.net.http.server.HttpHandler;
 
 import java.util.Objects;
 
-final class HateosResourceMappingsMappingHandlerHttpHandler extends HateosResourceMappingsMappingHandler<HttpHandler> {
+final class HateosResourceMappingsMappingHandlerHttpHandler<I extends Comparable<I>, V, C, H extends HateosResource<I>, X extends HateosResourceHandlerContext> extends HateosResourceMappingsMappingHandler<I, V, C, H, X> {
 
-    static HateosResourceMappingsMappingHandlerHttpHandler with(final HttpHandler handler) {
-        return new HateosResourceMappingsMappingHandlerHttpHandler(
+    static <I extends Comparable<I>, V, C, H extends HateosResource<I>, X extends HateosResourceHandlerContext> HateosResourceMappingsMappingHandlerHttpHandler<I, V, C, H, X> with(final HttpHandler handler) {
+        return new HateosResourceMappingsMappingHandlerHttpHandler<>(
             Objects.requireNonNull(handler, "handler")
         );
     }
 
     private HateosResourceMappingsMappingHandlerHttpHandler(final HttpHandler handler) {
-        super(handler);
+        super();
+        this.handler = handler;
     }
 
     @Override
-    void handle(final HateosResourceMappingsRouterHttpHandlerRequest request,
-                final HateosResourceMappings<?, ?, ?, ?, ?> mappings,
+    void handle(final HateosResourceMappingsRouterHttpHandlerRequest<X> request,
+                final HateosResourceMappings<I, V, C, H, X> mappings,
                 final HateosResourceSelection<?> selection,
                 final UrlPath path,
                 final HateosResourceHandlerContext context) {
@@ -45,4 +46,11 @@ final class HateosResourceMappingsMappingHandlerHttpHandler extends HateosResour
             request.response
         );
     }
+
+    @Override
+    HttpHandler handler() {
+        return this.handler;
+    }
+
+    private final HttpHandler handler;
 }

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouter.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouter.java
@@ -38,20 +38,20 @@ import java.util.Set;
  * A {@link Router} that dispatches to the given {@link HateosResourceMappings mappings}.
  * Note that any exceptions that are thrown, will have their stack trace in the response body with content-type=text/plain
  */
-final class HateosResourceMappingsRouter implements Router<HttpRequestAttribute<?>, HttpHandler> {
+final class HateosResourceMappingsRouter<X extends HateosResourceHandlerContext> implements Router<HttpRequestAttribute<?>, HttpHandler> {
 
-    static HateosResourceMappingsRouter with(final UrlPath base,
-                                             final Set<HateosResourceMappings<?, ?, ?, ?, ?>> mappings,
-                                             final Indentation indentation,
-                                             final LineEnding lineEnding,
-                                             final HateosResourceHandlerContext context) {
+    static <X extends HateosResourceHandlerContext> HateosResourceMappingsRouter<X> with(final UrlPath base,
+                                                                                         final Set<HateosResourceMappings<?, ?, ?, ?, X>> mappings,
+                                                                                         final Indentation indentation,
+                                                                                         final LineEnding lineEnding,
+                                                                                         final X context) {
         Objects.requireNonNull(base, "base");
         Objects.requireNonNull(mappings, "mappings");
         Objects.requireNonNull(indentation, "indentation");
         Objects.requireNonNull(lineEnding, "lineEnding");
         Objects.requireNonNull(context, "context");
 
-        return new HateosResourceMappingsRouter(
+        return new HateosResourceMappingsRouter<>(
             base,
             mappings,
             indentation,
@@ -61,15 +61,15 @@ final class HateosResourceMappingsRouter implements Router<HttpRequestAttribute<
     }
 
     private HateosResourceMappingsRouter(final UrlPath base,
-                                         final Set<HateosResourceMappings<?, ?, ?, ?, ?>> mappings,
+                                         final Set<HateosResourceMappings<?, ?, ?, ?, X>> mappings,
                                          final Indentation indentation,
                                          final LineEnding lineEnding,
-                                         final HateosResourceHandlerContext context) {
+                                         final X context) {
         super();
         this.base = base.normalize();
-        Map<HateosResourceName, HateosResourceMappings<?, ?, ?, ?, ?>> resourceNameToMapping = Maps.sorted();
+        Map<HateosResourceName, HateosResourceMappings<?, ?, ?, ?, X>> resourceNameToMapping = Maps.sorted();
 
-        for (final HateosResourceMappings<?, ?, ?, ?, ?> mappingsMappings : mappings) {
+        for (final HateosResourceMappings<?, ?, ?, ?, X> mappingsMappings : mappings) {
             resourceNameToMapping.put(
                 mappingsMappings.resourceName,
                 mappingsMappings
@@ -84,7 +84,7 @@ final class HateosResourceMappingsRouter implements Router<HttpRequestAttribute<
         this.context = context;
     }
 
-    final Map<HateosResourceName, HateosResourceMappings<?, ?, ?, ?, ?>> resourceNameToMapping;
+    final Map<HateosResourceName, HateosResourceMappings<?, ?, ?, ?, X>> resourceNameToMapping;
 
     // Router...........................................................................................................
 
@@ -136,7 +136,10 @@ final class HateosResourceMappingsRouter implements Router<HttpRequestAttribute<
      */
     private final LineEnding lineEnding;
 
-    private final HateosResourceHandlerContext context;
+    /**
+     * The shared or common context passed to all handlers when they are invoked.
+     */
+    private final X context;
 
     // toString.........................................................................................................
 

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessorTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessorTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.http.server.hateos;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.naming.Names;
 import walkingkooka.naming.StringName;
@@ -28,6 +29,7 @@ import walkingkooka.net.header.LinkRelation;
 import walkingkooka.net.header.MediaType;
 import walkingkooka.net.http.HttpMethod;
 import walkingkooka.net.http.server.FakeHttpHandler;
+import walkingkooka.net.http.server.hateos.HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessorTest.TestHateosResourceHandlerContext;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContextObjectPostProcessorTesting;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContexts;
@@ -36,8 +38,8 @@ import java.math.BigInteger;
 import java.util.Set;
 import java.util.function.BiFunction;
 
-public final class HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessorTest extends HateosResourceMappingsTestCase<HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor>
-        implements JsonNodeMarshallContextObjectPostProcessorTesting<HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor> {
+public final class HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessorTest extends HateosResourceMappingsTestCase<HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor<TestHateosResourceHandlerContext>>
+    implements JsonNodeMarshallContextObjectPostProcessorTesting<HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor<TestHateosResourceHandlerContext>> {
 
     // apply............................................................................................................
 
@@ -89,14 +91,14 @@ public final class HateosResourceMappingsJsonNodeMarshallContextObjectPostProces
     public void testToString() {
         this.toStringAndCheck(
                 this.createBiFunction(),
-                "{walkingkooka.net.http.server.hateos.TestHateosResource=resource-1, self=POST, contents=GET, POST, walkingkooka.net.http.server.hateos.TestHateosResource2=resource-2, about=PUT}"
+            "{walkingkooka.net.http.server.hateos.TestHateosResource=resource-1, self=POST, contents=GET, POST, walkingkooka.net.http.server.hateos.TestHateosResource2=resource-2, about=PUT}"
         );
     }
 
     // BiFunction.......................................................................................................
 
     @Override
-    public HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor createBiFunction() {
+    public HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor<TestHateosResourceHandlerContext> createBiFunction() {
         return HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor.with(
                 this.baseUrl(),
                 this.mappings(),
@@ -116,22 +118,22 @@ public final class HateosResourceMappingsJsonNodeMarshallContextObjectPostProces
         return HateosResourceName.with("resource-2");
     }
 
-    private Set<HateosResourceMappings<?, ?, ?, ?, ?>> mappings() {
+    private Set<HateosResourceMappings<?, ?, ?, ?, TestHateosResourceHandlerContext>> mappings() {
         final HateosResourceName resourceName1 = this.resourceName1();
         final HateosResourceName resourceName2 = this.resourceName2();
 
-        final HateosResourceMappings<?, ?, ?, ?, ?> mappings1 = HateosResourceMappings.with(
+        final HateosResourceMappings<BigInteger, TestResource, TestResource, TestHateosResource, TestHateosResourceHandlerContext> mappings1 = HateosResourceMappings.with(
                         resourceName1,
                         this.selectionParser(),
                         TestResource.class,
-                        TestResource2.class,
+                TestResource.class,
                         TestHateosResource.class,
                         TestHateosResourceHandlerContext.class
                 ).setHateosResourceHandler(LinkRelation.CONTENTS, HttpMethod.GET, new FakeHateosResourceHandler<>())
                 .setHateosResourceHandler(LinkRelation.CONTENTS, HttpMethod.POST, new FakeHateosResourceHandler<>())
                 .setHateosResourceHandler(LinkRelation.SELF, HttpMethod.POST, new FakeHateosResourceHandler<>());
 
-        final HateosResourceMappings<?, ?, ?, ?, ?> mappings2 = HateosResourceMappings.with(
+        final HateosResourceMappings<BigInteger, TestResource, TestResource2, TestHateosResource2, TestHateosResourceHandlerContext> mappings2 = HateosResourceMappings.with(
                 resourceName2,
                 this.selectionParser(),
                 TestResource.class,
@@ -147,7 +149,10 @@ public final class HateosResourceMappingsJsonNodeMarshallContextObjectPostProces
                 new FakeHttpHandler()
         );
 
-        return Sets.of(mappings1, mappings2);
+        return Sets.of(
+            mappings1,
+            mappings2
+        );
     }
 
     private BiFunction<String, TestHateosResourceHandlerContext, HateosResourceSelection<BigInteger>> selectionParser() {
@@ -170,11 +175,11 @@ public final class HateosResourceMappingsJsonNodeMarshallContextObjectPostProces
         }
     }
 
-    // ClassTesting......................................................................................................
+    // ClassTesting.....................................................................................................
 
     @Override
-    public Class<HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor> type() {
-        return HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor.class;
+    public Class<HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor<TestHateosResourceHandlerContext>> type() {
+        return Cast.to(HateosResourceMappingsJsonNodeMarshallContextObjectPostProcessor.class);
     }
 
     // TypeNameTesting..................................................................................................

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterTest.java
@@ -50,6 +50,7 @@ import walkingkooka.net.http.server.HttpRequestAttribute;
 import walkingkooka.net.http.server.HttpRequestParameterName;
 import walkingkooka.net.http.server.HttpResponse;
 import walkingkooka.net.http.server.HttpResponses;
+import walkingkooka.net.http.server.hateos.HateosResourceMappingsRouterTest.TestHateosResourceHandlerContext;
 import walkingkooka.route.Router;
 import walkingkooka.route.RouterTesting2;
 import walkingkooka.text.CharSequences;
@@ -73,8 +74,8 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class HateosResourceMappingsRouterTest extends HateosResourceMappingsTestCase<HateosResourceMappingsRouter>
-        implements RouterTesting2<HateosResourceMappingsRouter, HttpRequestAttribute<?>, HttpHandler> {
+public final class HateosResourceMappingsRouterTest extends HateosResourceMappingsTestCase<HateosResourceMappingsRouter<TestHateosResourceHandlerContext>>
+    implements RouterTesting2<HateosResourceMappingsRouter<TestHateosResourceHandlerContext>, HttpRequestAttribute<?>, HttpHandler> {
 
     private final static String NO_BODY = null;
 
@@ -92,7 +93,7 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
 
     private final static CharsetName DEFAULT_CHARSET = CharsetName.UTF_8;
 
-    private final static Set<HateosResourceMappings<?, ?, ?, ?, ?>> MAPPINGS = Sets.empty();
+    private final static Set<HateosResourceMappings<?, ?, ?, ?, TestHateosResourceHandlerContext>> MAPPINGS = Sets.empty();
     private final static Indentation INDENTATION = Indentation.SPACES2;
     private final static LineEnding LINE_ENDING = LineEnding.NL;
 
@@ -744,7 +745,7 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
                                      final String body,
                                      final Class<? extends Throwable> thrownType,
                                      final String thrownMessage) {
-        final HateosResourceMappingsRouter router = this.createRouter(handler);
+        final HateosResourceMappingsRouter<TestHateosResourceHandlerContext> router = this.createRouter(handler);
 
         final MediaType contentType = this.contentType();
         final Map<HttpHeaderName<?>, List<?>> headers = Maps.sorted();
@@ -1676,11 +1677,13 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
     // HELPERS .........................................................................................................
 
     @Override
-    public HateosResourceMappingsRouter createRouter() {
-        return this.createRouter(new FakeHateosResourceHandler<>());
+    public HateosResourceMappingsRouter<TestHateosResourceHandlerContext> createRouter() {
+        return this.createRouter(
+            new FakeHateosResourceHandler<>()
+        );
     }
 
-    private HateosResourceMappingsRouter createRouter(final HateosResourceHandler<BigInteger, TestResource, TestResource, TestHateosResourceHandlerContext> handler) {
+    private HateosResourceMappingsRouter<TestHateosResourceHandlerContext> createRouter(final HateosResourceHandler<BigInteger, TestResource, TestResource, TestHateosResourceHandlerContext> handler) {
         final HateosResourceMappings<BigInteger, TestResource, TestResource, TestHateosResource, TestHateosResourceHandlerContext> getMapping = this.getMapping()
                 .setHateosResourceHandler(LinkRelation.SELF, HttpMethod.GET, handler);
 
@@ -1858,7 +1861,7 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
         );
     }
 
-    private void routeAndCheck(final HateosResourceMappingsRouter router,
+    private void routeAndCheck(final HateosResourceMappingsRouter<TestHateosResourceHandlerContext> router,
                                final String url,
                                final String body,
                                final HttpStatus status,
@@ -1877,7 +1880,7 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
     /**
      * Also computes and adds a content-length header.
      */
-    private void routeAndCheck(final HateosResourceMappingsRouter router,
+    private void routeAndCheck(final HateosResourceMappingsRouter<TestHateosResourceHandlerContext> router,
                                final HttpMethod method,
                                final String url,
                                final MediaType contentType,
@@ -1933,7 +1936,7 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
         );
     }
 
-    private void routeAndCheck(final HateosResourceMappingsRouter router,
+    private void routeAndCheck(final HateosResourceMappingsRouter<TestHateosResourceHandlerContext> router,
                                final HttpMethod method,
                                final String url,
                                final Map<HttpHeaderName<?>, List<?>> headers,
@@ -2131,7 +2134,7 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
     // ClassTesting.....................................................................................................
 
     @Override
-    public Class<HateosResourceMappingsRouter> type() {
+    public Class<HateosResourceMappingsRouter<TestHateosResourceHandlerContext>> type() {
         return Cast.to(HateosResourceMappingsRouter.class);
     }
 }


### PR DESCRIPTION
- HateosResourceMappingsMappingHandlerHateosXXX replaced all wildcards with actual type parameters.
- HateosResourceMappingsRouterHttpHandlerRequest replaced HateosResourceHandlerContext with type-parameter X
- HateosResourceMappingsMapping Map wildcards replaced with some type-parameters.
- HateosResourceMappingsRouter made more type safe HateosResourceHandlerContext replaced by type-parameter.