### PR TITLE
HateosResourceMappingsRouter.with Context removed

### DIFF
--- a/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
+++ b/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
@@ -22,9 +22,9 @@ import walkingkooka.net.http.server.HttpRequestAttribute;
 import walkingkooka.net.http.server.HttpRequestParameterName;
 import walkingkooka.net.http.server.HttpResponse;
 import walkingkooka.net.http.server.HttpResponses;
+import walkingkooka.net.http.server.hateos.FakeHateosHandlerContext;
 import walkingkooka.net.http.server.hateos.FakeHateosResource;
 import walkingkooka.net.http.server.hateos.FakeHateosResourceHandler;
-import walkingkooka.net.http.server.hateos.FakeHateosResourceHandlerContext;
 import walkingkooka.net.http.server.hateos.HateosResourceMappings;
 import walkingkooka.net.http.server.hateos.HateosResourceName;
 import walkingkooka.net.http.server.hateos.HateosResourceSelection;
@@ -115,12 +115,9 @@ public class TestGwtTest extends GWTTestCase {
             }
         );
 
-        final TestHateosResourceHandlerContext context = new TestHateosResourceHandlerContext();
-
         final Router<HttpRequestAttribute<?>, HttpHandler<TestHateosResourceHandlerContext>> router = HateosResourceMappings.router(
             UrlPath.parse("/api"),
-            Sets.of(mapping),
-            context
+            Sets.of(mapping)
         );
 
         final HttpRequest request = new FakeHttpRequest() {
@@ -181,7 +178,7 @@ public class TestGwtTest extends GWTTestCase {
         httpHandler.handle(
             request,
             response,
-            context
+            new TestHateosResourceHandlerContext()
         );
         checkEquals(
             "{\n" +
@@ -195,7 +192,7 @@ public class TestGwtTest extends GWTTestCase {
         );
     }
 
-    static class TestHateosResourceHandlerContext extends FakeHateosResourceHandlerContext {
+    static class TestHateosResourceHandlerContext extends FakeHateosHandlerContext {
 
         final static MediaType CONTENT_TYPE = MediaType.parse("application/test-json");
 

--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -39,9 +39,9 @@ import walkingkooka.net.http.server.HttpRequestAttribute;
 import walkingkooka.net.http.server.HttpRequestParameterName;
 import walkingkooka.net.http.server.HttpResponse;
 import walkingkooka.net.http.server.HttpResponses;
+import walkingkooka.net.http.server.hateos.FakeHateosHandlerContext;
 import walkingkooka.net.http.server.hateos.FakeHateosResource;
 import walkingkooka.net.http.server.hateos.FakeHateosResourceHandler;
-import walkingkooka.net.http.server.hateos.FakeHateosResourceHandlerContext;
 import walkingkooka.net.http.server.hateos.HateosResourceMappings;
 import walkingkooka.net.http.server.hateos.HateosResourceName;
 import walkingkooka.net.http.server.hateos.HateosResourceSelection;
@@ -135,8 +135,7 @@ public class JunitTest {
 
         final Router<HttpRequestAttribute<?>, HttpHandler<TestHateosResourceHandlerContext>> router = HateosResourceMappings.router(
             UrlPath.parse("/api"),
-            Sets.of(mapping),
-            context
+            Sets.of(mapping)
         );
 
         final HttpRequest request = new FakeHttpRequest() {
@@ -211,7 +210,7 @@ public class JunitTest {
         );
     }
 
-    static class TestHateosResourceHandlerContext extends FakeHateosResourceHandlerContext {
+    static class TestHateosResourceHandlerContext extends FakeHateosHandlerContext {
 
         final static MediaType CONTENT_TYPE = MediaType.parse("application/test-json");
 

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappings.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappings.java
@@ -262,12 +262,10 @@ public final class HateosResourceMappings<I extends Comparable<I>, V, C, H exten
      * Creates a {@link Router} from the provided {@link HateosResourceMappings mappings}.
      */
     public static <X extends HateosHandlerContext> Router<HttpRequestAttribute<?>, HttpHandler<X>> router(final UrlPath base,
-                                                                                                          final Set<HateosResourceMappings<?, ?, ?, ?, X>> mappings,
-                                                                                                          final X context) {
+                                                                                                          final Set<HateosResourceMappings<?, ?, ?, ?, X>> mappings) {
         return HateosResourceMappingsRouter.with(
             base,
-            mappings,
-            context
+            mappings
         );
     }
 

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouter.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouter.java
@@ -39,22 +39,18 @@ import java.util.Set;
 final class HateosResourceMappingsRouter<C extends HateosHandlerContext> implements Router<HttpRequestAttribute<?>, HttpHandler<C>> {
 
     static <C extends HateosHandlerContext> HateosResourceMappingsRouter<C> with(final UrlPath base,
-                                                                                 final Set<HateosResourceMappings<?, ?, ?, ?, C>> mappings,
-                                                                                 final C context) {
+                                                                                 final Set<HateosResourceMappings<?, ?, ?, ?, C>> mappings) {
         Objects.requireNonNull(base, "base");
         Objects.requireNonNull(mappings, "mappings");
-        Objects.requireNonNull(context, "context");
 
         return new HateosResourceMappingsRouter<>(
             base,
-            mappings,
-            context
+            mappings
         );
     }
 
     private HateosResourceMappingsRouter(final UrlPath base,
-                                         final Set<HateosResourceMappings<?, ?, ?, ?, C>> mappings,
-                                         final C context) {
+                                         final Set<HateosResourceMappings<?, ?, ?, ?, C>> mappings) {
         super();
         this.base = base.normalize();
         Map<HateosResourceName, HateosResourceMappings<?, ?, ?, ?, C>> resourceNameToMapping = Maps.sorted();
@@ -67,8 +63,6 @@ final class HateosResourceMappingsRouter<C extends HateosHandlerContext> impleme
         }
 
         this.resourceNameToMapping = resourceNameToMapping;
-
-        this.context = context;
     }
 
     final Map<HateosResourceName, HateosResourceMappings<?, ?, ?, ?, C>> resourceNameToMapping;
@@ -83,8 +77,7 @@ final class HateosResourceMappingsRouter<C extends HateosHandlerContext> impleme
         return Optional.ofNullable(
             -1 != this.consumeBasePath(parameters) ?
                 HateosResourceMappingsRouterHttpHandler.with(
-                    this,
-                    this.context
+                    this
                 ) :
                 null
         );
@@ -106,11 +99,6 @@ final class HateosResourceMappingsRouter<C extends HateosHandlerContext> impleme
     }
 
     private final UrlPath base;
-
-    /**
-     * The shared or common context passed to all handlers when they are invoked.
-     */
-    private final C context;
 
     // toString.........................................................................................................
 

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterHttpHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterHttpHandler.java
@@ -32,22 +32,16 @@ final class HateosResourceMappingsRouterHttpHandler<C extends HateosHandlerConte
     /**
      * Factory called by {@link HateosResourceMappingsRouter#route}
      */
-    static <C extends HateosHandlerContext> HateosResourceMappingsRouterHttpHandler<C> with(final HateosResourceMappingsRouter<C> router,
-                                                                                            final C context) {
-        return new HateosResourceMappingsRouterHttpHandler<>(
-            router,
-            context
-        );
+    static <C extends HateosHandlerContext> HateosResourceMappingsRouterHttpHandler<C> with(final HateosResourceMappingsRouter<C> router) {
+        return new HateosResourceMappingsRouterHttpHandler<>(router);
     }
 
     /**
      * Private ctor use factory.
      */
-    private HateosResourceMappingsRouterHttpHandler(final HateosResourceMappingsRouter<C> router,
-                                                    final C context) {
+    private HateosResourceMappingsRouterHttpHandler(final HateosResourceMappingsRouter<C> router) {
         super();
         this.router = router;
-        this.context = context;
     }
 
     @Override
@@ -62,13 +56,11 @@ final class HateosResourceMappingsRouterHttpHandler<C extends HateosHandlerConte
             request,
             response,
             this.router,
-            this.context
+            context
         ).dispatch();
     }
 
     private final HateosResourceMappingsRouter<C> router;
-
-    private final C context;
 
     @Override
     public String toString() {

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterHttpHandlerRequestTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterHttpHandlerRequestTest.java
@@ -118,8 +118,7 @@ public final class HateosResourceMappingsRouterHttpHandlerRequestTest extends Ha
                         HttpMethod.GET,
                         HateosResourceHandlers.fake()
                     )
-                ),
-                context
+                )
             ),
             context
         ).dispatch();
@@ -140,8 +139,7 @@ public final class HateosResourceMappingsRouterHttpHandlerRequestTest extends Ha
 
         final HateosResourceMappingsRouter<HateosHandlerContext> router = HateosResourceMappingsRouter.with(
             UrlPath.parse("/path1/path2/"),
-            Sets.empty(),
-            context
+            Sets.empty()
         );
         final HttpRequest request = HttpRequests.fake();
         final HttpResponse response = HttpResponses.fake();
@@ -151,7 +149,7 @@ public final class HateosResourceMappingsRouterHttpHandlerRequestTest extends Ha
                 request,
                 response,
                 router,
-                context
+                HateosHandlerContexts.fake()
             ),
             "/path1/path2/ " + request + " " + response
         );

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterHttpHandlerTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterHttpHandlerTest.java
@@ -31,10 +31,8 @@ public final class HateosResourceMappingsRouterHttpHandlerTest extends HateosRes
         return HateosResourceMappingsRouterHttpHandler.with(
             HateosResourceMappingsRouter.with(
                 UrlPath.ROOT,
-                Sets.empty(),
-                HateosHandlerContexts.fake()
-            ),
-            HateosHandlerContexts.fake()
+                Sets.empty()
+            )
         );
     }
 
@@ -47,19 +45,13 @@ public final class HateosResourceMappingsRouterHttpHandlerTest extends HateosRes
 
     @Test
     public void testToString() {
-        final HateosHandlerContext context = HateosHandlerContexts.fake();
-
         final HateosResourceMappingsRouter<HateosHandlerContext> router = HateosResourceMappingsRouter.with(
             UrlPath.ROOT,
-            Sets.empty(),
-            context
+            Sets.empty()
         );
 
         this.toStringAndCheck(
-            HateosResourceMappingsRouterHttpHandler.with(
-                router,
-                context
-            ),
+            HateosResourceMappingsRouterHttpHandler.with(router),
             router.toString()
         );
     }

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterTest.java
@@ -144,8 +144,7 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
             NullPointerException.class,
             () -> HateosResourceMappingsRouter.with(
                 null,
-                MAPPINGS,
-                CONTEXT
+                MAPPINGS
             )
         );
     }
@@ -156,19 +155,6 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
             NullPointerException.class,
             () -> HateosResourceMappingsRouter.with(
                 BASE_PATH,
-                null,
-                CONTEXT
-            )
-        );
-    }
-
-    @Test
-    public void testWithNullContextFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> HateosResourceMappingsRouter.with(
-                BASE_PATH,
-                MAPPINGS,
                 null
             )
         );
@@ -1258,8 +1244,7 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
 
         final Router<HttpRequestAttribute<?>, HttpHandler<TestHateosHandlerContext>> router = HateosResourceMappings.router(
             UrlPath.parse("/api"),
-            Sets.of(mapping),
-            CONTEXT
+            Sets.of(mapping)
         );
 
         final HttpRequest request = new FakeHttpRequest() {
@@ -1435,8 +1420,7 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
 
         final Router<HttpRequestAttribute<?>, HttpHandler<TestHateosHandlerContext>> router = HateosResourceMappings.router(
             UrlPath.parse("/api"),
-            Sets.of(mapping),
-            CONTEXT
+            Sets.of(mapping)
         );
 
         final HttpRequest request = new FakeHttpRequest() {
@@ -1586,8 +1570,7 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
 
         final Router<HttpRequestAttribute<?>, HttpHandler<TestHateosHandlerContext>> router = HateosResourceMappings.router(
             UrlPath.parse("/api"),
-            Sets.of(mapping),
-            CONTEXT
+            Sets.of(mapping)
         );
 
         final HttpRequest request = new FakeHttpRequest() {
@@ -1703,8 +1686,7 @@ public final class HateosResourceMappingsRouterTest extends HateosResourceMappin
                 Sets.of(
                     getMapping,
                     mappingWithBody
-                ),
-                CONTEXT
+                )
             )
         );
     }

--- a/src/test/java/walkingkooka/net/http/server/hateos/sample/Sample.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/sample/Sample.java
@@ -139,12 +139,9 @@ public class Sample {
             }
         );
 
-        final TestHateosHandlerContext context = new TestHateosHandlerContext();
-
         final Router<HttpRequestAttribute<?>, HttpHandler<TestHateosHandlerContext>> router = HateosResourceMappings.router(
             UrlPath.parse("/api"),
-            Sets.of(mapping),
-            context
+            Sets.of(mapping)
         );
 
         final HttpRequest request = new FakeHttpRequest() {
@@ -205,7 +202,7 @@ public class Sample {
         httpHandler.handle(
             request,
             response,
-            context
+            new TestHateosHandlerContext()
         );
         checkEquals(
             "{\n" +


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net-http-server-hateos/issues/329
- HateosResourceMappingsRouter remove HateosResourceHandlerContext dependency