### PR TITLE
HateosResourceMappingsRouterHttpHandler extract lastModified from res…

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceHandler.java
@@ -32,6 +32,9 @@ import java.util.Set;
  * marshalling of the response to the response body.
  * Note that 2xx responses, especially {@link walkingkooka.net.http.HttpStatusCode#OK} and {@link walkingkooka.net.http.HttpStatusCode#NO_CONTENT},
  * response should always contain {@link HateosResourceMappings#X_CONTENT_TYPE_NAME}, which is used by the client to dispatch watcher events.
+ * <br>
+ * If the response value or collection implements {@link walkingkooka.datetime.HasLastModified} or {@link walkingkooka.datetime.HasOptionalLastModified},
+ * the {@link walkingkooka.net.header.HttpHeaderName#LAST_MODIFIED} will be set with that value.
  */
 public interface HateosResourceHandler<I extends Comparable<I>, V, C, X extends HateosHandlerContext> {
 
@@ -64,7 +67,7 @@ public interface HateosResourceHandler<I extends Comparable<I>, V, C, X extends 
                            final X context);
 
     /**
-     * Handles a resources identified by the given id
+     * Handles a resources identified by the given id.
      * <pre>
      * /resource/123
      * </pre>>

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterHttpHandlerRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterHttpHandlerRequest.java
@@ -470,12 +470,12 @@ final class HateosResourceMappingsRouterHttpHandlerRequest<X extends HateosHandl
 
             entity = HttpEntity.EMPTY
                 .setContentType(contentType.setCharset(charsetName))
+                .setLastModified(content)
                 .setBodyText(
                     context.toJsonText(
                         context.marshall(content)
                     )
-                )
-                .setContentLength();
+                ).setContentLength();
         } else {
             statusCode = HttpStatusCode.NO_CONTENT;
             entity = HttpEntity.EMPTY;

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterHttpHandlerTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceMappingsRouterHttpHandlerTest.java
@@ -20,6 +20,8 @@ package walkingkooka.net.http.server.hateos;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.set.Sets;
+import walkingkooka.datetime.HasLastModifiedTesting;
+import walkingkooka.datetime.HasOptionalLastModifiedTesting;
 import walkingkooka.net.Url;
 import walkingkooka.net.UrlPath;
 import walkingkooka.net.header.Accept;
@@ -46,6 +48,8 @@ import java.util.Optional;
 
 public final class HateosResourceMappingsRouterHttpHandlerTest extends HateosResourceMappingsTestCase<HateosResourceMappingsRouterHttpHandler<HateosHandlerContext>>
     implements HttpHandlerTesting<HateosResourceMappingsRouterHttpHandler<HateosHandlerContext>, HateosHandlerContext>,
+    HasLastModifiedTesting,
+    HasOptionalLastModifiedTesting,
     JsonNodeMarshallContextTesting {
 
     @Test
@@ -127,6 +131,191 @@ public final class HateosResourceMappingsRouterHttpHandlerTest extends HateosRes
                 "HTTP/1.0 200 OK\r\n" +
                     "Content-Length: 68\r\n" +
                     "Content-Type: application/json; charset=UTF-8\r\n" +
+                    "X-Content-Type-Name: TestResource\r\n" +
+                    "\r\n" +
+                    "{\n" +
+                    "  \"type\": \"test-HateosResource\",\n" +
+                    "  \"value\": {\n" +
+                    "    \"id\": \"31\"\n" +
+                    "  }\n" +
+                    "}"
+            )
+        );
+    }
+
+    @Test
+    public void testHandleHateosResourceWithHasLastModified() {
+        this.handleAndCheck(
+            HateosResourceMappingsRouterHttpHandler.with(
+                HateosResourceMappingsRouter.with(
+                    UrlPath.ROOT,
+                    Sets.of(
+                        HateosResourceMappings.with(
+                            HateosResourceName.with("TestResource2"),
+                            (s, x) -> {
+                                return HateosResourceSelection.one(
+                                    new BigInteger(s)
+                                );
+                            },
+                            TestResource2.class,
+                            TestResource2.class,
+                            TestHateosResource.class,
+                            HateosHandlerContext.class
+                        ).setHateosResourceHandler(
+                            LinkRelation.SELF,
+                            HttpMethod.GET,
+                            new FakeHateosResourceHandler<>() {
+
+                                @Override
+                                public Optional<TestResource2> handleOne(final BigInteger id,
+                                                                         final Optional<TestResource2> resource,
+                                                                         final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                                         final UrlPath path,
+                                                                         final HateosHandlerContext context) {
+                                    HateosResourceHandler.checkPathEmpty(path);
+
+                                    return Optional.of(
+                                        TestResource2.with(
+                                            TestHateosResource.with(
+                                                BigInteger.valueOf(31)
+                                            )
+                                        )
+                                    );
+                                }
+                            }
+                        )
+                    )
+                )
+            ),
+            HttpRequests.get(
+                HttpTransport.UNSECURED,
+                Url.parseRelative("/TestResource2/1"),
+                HttpProtocolVersion.VERSION_1_0,
+                HttpEntity.EMPTY.addHeader(
+                    HttpHeaderName.ACCEPT,
+                    Accept.DEFAULT
+                )
+            ),
+            new FakeHateosHandlerContext() {
+
+                @Override
+                public MediaType contentType() {
+                    return MediaType.APPLICATION_JSON;
+                }
+
+                @Override
+                public Indentation indentation() {
+                    return HateosResourceMappingsRouterHttpHandlerTest.INDENTATION;
+                }
+
+                @Override
+                public LineEnding lineEnding() {
+                    return EOL;
+                }
+
+                @Override
+                public JsonNode marshall(final Object value) {
+                    return JSON_NODE_MARSHALL_CONTEXT.marshall(value);
+                }
+            },
+            HttpResponses.parse(
+                "HTTP/1.0 200 OK\r\n" +
+                    "Content-Length: 68\r\n" +
+                    "Content-Type: application/json; charset=UTF-8\r\n" +
+                    "Last-Modified: Fri, 31 Dec 1999 12:58:59 GMT\r\n" +
+                    "X-Content-Type-Name: TestResource2\r\n" +
+                    "\r\n" +
+                    "{\n" +
+                    "  \"type\": \"test-HateosResource\",\n" +
+                    "  \"value\": {\n" +
+                    "    \"id\": \"31\"\n" +
+                    "  }\n" +
+                    "}"
+            )
+        );
+    }
+
+    @Test
+    public void testHandleHateosResourceWithHasOptionalLastModified() {
+        this.handleAndCheck(
+            HateosResourceMappingsRouterHttpHandler.with(
+                HateosResourceMappingsRouter.with(
+                    UrlPath.ROOT,
+                    Sets.of(
+                        HateosResourceMappings.with(
+                            HateosResourceName.with("TestResource"),
+                            (s, x) -> {
+                                return HateosResourceSelection.one(
+                                    new BigInteger(s)
+                                );
+                            },
+                            TestResource.class,
+                            TestResource.class,
+                            TestHateosResource.class,
+                            HateosHandlerContext.class
+                        ).setHateosResourceHandler(
+                            LinkRelation.SELF,
+                            HttpMethod.GET,
+                            new FakeHateosResourceHandler<>() {
+
+                                @Override
+                                public Optional<TestResource> handleOne(final BigInteger id,
+                                                                        final Optional<TestResource> resource,
+                                                                        final Map<HttpRequestAttribute<?>, Object> parameters,
+                                                                        final UrlPath path,
+                                                                        final HateosHandlerContext context) {
+                                    HateosResourceHandler.checkPathEmpty(path);
+
+                                    return Optional.of(
+                                        TestResource.with(
+                                            TestHateosResource.with(
+                                                BigInteger.valueOf(31)
+                                            ),
+                                            HateosResourceMappingsRouterHttpHandlerTest.NOW
+                                        )
+                                    );
+                                }
+                            }
+                        )
+                    )
+                )
+            ),
+            HttpRequests.get(
+                HttpTransport.UNSECURED,
+                Url.parseRelative("/TestResource/1"),
+                HttpProtocolVersion.VERSION_1_0,
+                HttpEntity.EMPTY.addHeader(
+                    HttpHeaderName.ACCEPT,
+                    Accept.DEFAULT
+                )
+            ),
+            new FakeHateosHandlerContext() {
+
+                @Override
+                public MediaType contentType() {
+                    return MediaType.APPLICATION_JSON;
+                }
+
+                @Override
+                public Indentation indentation() {
+                    return HateosResourceMappingsRouterHttpHandlerTest.INDENTATION;
+                }
+
+                @Override
+                public LineEnding lineEnding() {
+                    return EOL;
+                }
+
+                @Override
+                public JsonNode marshall(final Object value) {
+                    return JSON_NODE_MARSHALL_CONTEXT.marshall(value);
+                }
+            },
+            HttpResponses.parse(
+                "HTTP/1.0 200 OK\r\n" +
+                    "Content-Length: 68\r\n" +
+                    "Content-Type: application/json; charset=UTF-8\r\n" +
+                    "Last-Modified: Fri, 31 Dec 1999 12:58:59 GMT\r\n" +
                     "X-Content-Type-Name: TestResource\r\n" +
                     "\r\n" +
                     "{\n" +

--- a/src/test/java/walkingkooka/net/http/server/hateos/TestResource.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/TestResource.java
@@ -18,26 +18,54 @@
 package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.Cast;
+import walkingkooka.datetime.HasOptionalLastModified;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeContext;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 /**
  * A simple container for the actual {@link HateosResource}.
  */
-public final class TestResource {
+public final class TestResource implements HasOptionalLastModified {
 
     static TestResource with(final Object value) {
-        return new TestResource(value);
+        return new TestResource(
+            value,
+            null
+        );
     }
 
-    private TestResource(final Object value) {
+    static TestResource with(final Object value,
+                             final LocalDateTime lastModified) {
+        return new TestResource(
+            value,
+            lastModified
+        );
+    }
+
+    private TestResource(final Object value,
+                         final LocalDateTime lastModified) {
         super();
         this.value = value;
+        this.lastModified = lastModified;
     }
 
     final Object value;
+
+    // HasOptionalLastModified..........................................................................................
+
+    @Override
+    public Optional<LocalDateTime> lastModified() {
+        return Optional.ofNullable(
+            this.lastModified
+        );
+    }
+
+    private final LocalDateTime lastModified;
 
     // JsonNodeContext...................................................................................................
 

--- a/src/test/java/walkingkooka/net/http/server/hateos/TestResource2.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/TestResource2.java
@@ -18,15 +18,20 @@
 package walkingkooka.net.http.server.hateos;
 
 import walkingkooka.Cast;
+import walkingkooka.datetime.HasLastModified;
+import walkingkooka.datetime.HasLastModifiedTesting;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeContext;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
+import java.time.LocalDateTime;
+
 /**
  * A simple container for the actual {@link HateosResource}.
  */
-public final class TestResource2 {
+public final class TestResource2 implements HasLastModified,
+    HasLastModifiedTesting {
 
     static TestResource2 with(final Object value) {
         return new TestResource2(value);
@@ -38,6 +43,13 @@ public final class TestResource2 {
     }
 
     final Object value;
+
+    // HasLastModified..................................................................................................
+
+    @Override
+    public LocalDateTime lastModified() {
+        return LAST_MODIFIED;
+    }
 
     // JsonNodeContext...................................................................................................
 


### PR DESCRIPTION
…ponse value or collection

- Closes https://github.com/mP1/walkingkooka-net-http-server-hateos/issues/362
- HateosResourceMappingsRouterHttpHandler should add lastModified header if HttpResource implements HasLastModified & HasOptionalLastModified